### PR TITLE
fix(journey): days-together uses 交往日期, trim ISO date in timeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -489,8 +489,8 @@ const LoveTimeApp = () => {
     },
     {
       id: 'first_date',
-      type: 'first_date', 
-      date: '2024-01-15',
+      type: 'first_date',
+      date: '',
       title: '開始交往',
       description: '緊張又興奮的第一次約會，從此心中只有彼此'
     },
@@ -1769,8 +1769,11 @@ const LoveTimeApp = () => {
   const formatChineseDate = (d: Date): string =>
     `${chineseYear(d.getFullYear())}年${toChineseNum(d.getMonth() + 1)}月${toChineseNum(d.getDate())}日`;
 
-  // Earliest meaningful "together since" date — earliest record, else user account.
+  // "Together since" date — prefers the user-set 交往日期 milestone, then
+  // earliest intimate record, then the account creation date.
   const togetherSince = (() => {
+    const firstDate = journeyMilestones.find(m => m.type === 'first_date')?.date;
+    if (firstDate) return new Date(firstDate);
     if (intimateRecords.length > 0) {
       const earliest = intimateRecords.reduce(
         (min, r) => (r.date < min.date ? r : min),
@@ -4271,7 +4274,7 @@ const LoveTimeApp = () => {
                       <div>
                         <h3 className="font-display text-lg font-medium tracking-tight text-petal-ink">{milestone.title}</h3>
                         <p className="font-display italic font-light text-sm text-petal-muted mt-0.5">
-                          {milestone.date || (milestone.place ? '—' : '')}
+                          {milestone.date ? milestone.date.slice(0, 10) : (milestone.place ? '—' : '')}
                         </p>
                         {milestone.place && (
                           <p className="font-body text-xs text-petal-muted">地點：{milestone.place}</p>


### PR DESCRIPTION
## Summary
- Switch the header's "days together" counter to use the user-set 交往日期 (`first_date` milestone) as the source of truth, falling back to earliest intimate record → `createdAt` only when it's unset.
- Trim the journey timeline date display to `YYYY-MM-DD` so it no longer shows raw ISO strings like `2008-10-05T00:00:00.000Z` (pg returns `DATE` columns as JS `Date`, which JSON-serializes with the time + `Z`).
- Clear the placeholder `'2024-01-15'` default for `first_date` so unset users fall through to the existing fallback chain instead of counting from a fake date.

## Test plan
- [x] `npm run test:e2e` — 12/12 green
- [ ] Open the staging URL on phone (auto-deployed via the new PR workflow), check the header counter reads the right number when 交往日期 is set
- [ ] Open 愛情旅程; confirm each set date renders as `YYYY-MM-DD`, no trailing `T00:00:00.000Z`
- [ ] Toggle 交往日期 unset in settings; confirm header falls back to earliest intimate record (or account-creation date if no records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)