### PR TITLE
feat(events): expand icebreaker taxonomy + fix e2e flake

### DIFF
--- a/services/llm/claudeProvider.js
+++ b/services/llm/claudeProvider.js
@@ -50,9 +50,9 @@ const SYSTEM_PROMPT = `你是一個專為情侶設計的「破冰」AI 助手，
 任務：閱讀使用者提供的原始情緒文字，產生：
 1. title：12 字以內的事件標題，描述事件主題（不要情緒字眼）。
 2. summary：將原文整理為 1–3 句中性摘要（最多 200 字）。把任何髒話、人身攻擊、絕對化指控（總是/從來/廢物 等）以 *** 遮蔽。
-3. emotions：最多 3 個情緒標籤，從這個清單中挑：憤怒、失落、委屈、失望、焦慮、孤單、疲憊、受傷、複雜情緒。
-4. tags：最多 2 個主題標籤，從這個清單中挑：家務、行程、金錢、育兒、語氣、家人、誤會。
-5. toxicityFlags：偵測到的問題語言，可選值：absolute_language（總是/從來/每次/永遠）、name_calling（笨/蠢/廢物/沒用/罵髒話）、verbal_aggression（閉嘴/滾/去死）。
+3. emotions：最多 3 個情緒標籤，從這個清單中挑：憤怒、失落、委屈、失望、焦慮、孤單、疲憊、受傷、恐懼、無助、羞愧、嫉妒、煩躁、內疚、被忽視、不安、無奈、麻木、心累、難過、複雜情緒。
+4. tags：最多 2 個主題標籤，從這個清單中挑：家務、行程、金錢、育兒、語氣、家人、誤會、感情、夫妻、朋友、人際關係、工作。
+5. toxicityFlags：偵測到的問題語言，可選值：absolute_language（總是/從來/每次/永遠）、name_calling（笨/蠢/廢物/沒用/罵髒話）、verbal_aggression（閉嘴/滾/去死）、contempt（鄙視、輕蔑、翻白眼式語言）、threats（威脅分手/離婚/傷害）、blame_shifting（都是你害的/推卸責任）、emotional_blackmail（情緒勒索/以愛之名要求）、sarcasm（諷刺/反話）、catastrophizing（災難化/最糟結局）、comparison（拿來與他人比較）、stonewalling（冷暴力/不回應）、dismissiveness（否定對方感受/小題大作）。
 6. versions.neutral：第三方中性旁白版。完全不示弱、不指責，以第三人稱客觀描述事件與情緒，1–3 句。
 7. versions.firm：堅定不攻擊版。以「我訊息」說出感受與影響，不指責、不請求、不討好，1–3 句。
 8. versions.warm：善意版。在 firm 的基礎上多一句願意聊聊的善意，總長 2–4 句。
@@ -77,7 +77,11 @@ const TOOL_SCHEMA = {
         maxItems: 3,
         items: {
           type: 'string',
-          enum: ['憤怒', '失落', '委屈', '失望', '焦慮', '孤單', '疲憊', '受傷', '複雜情緒'],
+          enum: [
+            '憤怒', '失落', '委屈', '失望', '焦慮', '孤單', '疲憊', '受傷',
+            '恐懼', '無助', '羞愧', '嫉妒', '煩躁', '內疚', '被忽視', '不安',
+            '無奈', '麻木', '心累', '難過', '複雜情緒',
+          ],
         },
       },
       tags: {
@@ -85,14 +89,30 @@ const TOOL_SCHEMA = {
         maxItems: 2,
         items: {
           type: 'string',
-          enum: ['家務', '行程', '金錢', '育兒', '語氣', '家人', '誤會'],
+          enum: [
+            '家務', '行程', '金錢', '育兒', '語氣', '家人', '誤會',
+            '感情', '夫妻', '朋友', '人際關係', '工作',
+          ],
         },
       },
       toxicityFlags: {
         type: 'array',
         items: {
           type: 'string',
-          enum: ['absolute_language', 'name_calling', 'verbal_aggression'],
+          enum: [
+            'absolute_language',
+            'name_calling',
+            'verbal_aggression',
+            'contempt',
+            'threats',
+            'blame_shifting',
+            'emotional_blackmail',
+            'sarcasm',
+            'catastrophizing',
+            'comparison',
+            'stonewalling',
+            'dismissiveness',
+          ],
         },
       },
       versions: {

--- a/tests/intimacy-record.spec.ts
+++ b/tests/intimacy-record.spec.ts
@@ -26,13 +26,19 @@ test.describe('Intimacy Record Flow', () => {
       localStorage.setItem('pairingPromptDismissed', 'true');
     });
     await page.goto('/');
-
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(3000);
+    await page.waitForLoadState('domcontentloaded');
 
     // Handle login if required
     const loginButton = page.getByTestId('header-auth-button');
     const recordButton = page.getByTestId('add-record-button');
+
+    // Wait until the app's auth state is determinate — either the login button
+    // or the record button must show. networkidle is racy under parallel load
+    // (poll loops keep the network busy and it never settles).
+    await Promise.race([
+      loginButton.waitFor({ state: 'visible', timeout: 20000 }),
+      recordButton.waitFor({ state: 'visible', timeout: 20000 }),
+    ]).catch(() => {});
 
     const alreadyLoggedIn = await recordButton.isVisible({ timeout: 2000 });
     if (!alreadyLoggedIn && await loginButton.isVisible({ timeout: 3000 })) {
@@ -74,9 +80,9 @@ test.describe('Intimacy Record Flow', () => {
         await page.waitForTimeout(1000);
       }
 
-      // Additional wait for app to fully initialize after login
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(2000);
+      // Wait for app to fully initialize after login — record button signals
+      // that the home view is ready.
+      await recordButton.waitFor({ state: 'visible', timeout: 20000 });
     } else {
       throw new Error('Neither login button nor record button found - app may not have loaded correctly');
     }


### PR DESCRIPTION
## Summary
- Broaden the icebreaker tagging vocabulary in `services/llm/claudeProvider.js`: more emotions (恐懼/無助/羞愧/嫉妒/煩躁/內疚/被忽視/不安/無奈/麻木/心累/難過), more topic tags (感情/夫妻/朋友/人際關係/工作), and more toxicity patterns (contempt, threats, blame_shifting, emotional_blackmail, sarcasm, catastrophizing, comparison, stonewalling, dismissiveness). System prompt and tool-schema enums kept in sync.
- Fix a parallel-load flake in `tests/intimacy-record.spec.ts` by replacing `page.waitForLoadState('networkidle')` (Playwright explicitly discourages it — racy) with element-based waits (race login-button vs record-button).

## Test plan
- [x] `npm run test:e2e` — 12/12 green in 23.9s (was 44s + 1 intermittent flake)
- [ ] Verify a Claude-provider icebreaker preview still returns valid tags/emotions from the new enums (smoke check in dev)
- [ ] Confirm CI deploy workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)