### PR TITLE
feat(events): notification deep-link + AI reply rewrite + step-bar hints

### DIFF
--- a/routes/events.js
+++ b/routes/events.js
@@ -480,6 +480,49 @@ router.post(
   }
 );
 
+// Preview-only AI rewrite for a reply. Stateless — no DB write. Loads the
+// event summary + recent messages so the LLM can rewrite the draft in context.
+router.post(
+  '/:id/messages/preview-rewrite',
+  [
+    param('id').isUUID(),
+    body('rawReply').isString().isLength({ min: 1, max: 2000 }).withMessage('回覆需在 1–2000 字之間'),
+  ],
+  async (req, res) => {
+    if (sendValidationError(req, res)) return;
+    try {
+      const access = await assertEventAccess(req.params.id, req.user.id);
+      if (!access) return res.status(404).json({ success: false, message: '找不到事件或沒有權限' });
+      if (access.event.is_private) {
+        return res.status(403).json({ success: false, message: '私人事件不支援 AI 回覆改寫' });
+      }
+
+      const recent = await db.query(
+        `SELECT sender_id, content
+           FROM event_messages
+          WHERE event_id = $1
+          ORDER BY created_at DESC
+          LIMIT 5`,
+        [req.params.id]
+      );
+      const recentMessages = recent.rows.reverse().map((m) => ({
+        fromSelf: m.sender_id === req.user.id,
+        content: m.content,
+      }));
+
+      const preview = await llmService.rewriteReply({
+        rawReply: req.body.rawReply,
+        eventSummary: access.event.summary,
+        recentMessages,
+      });
+      res.json({ success: true, preview });
+    } catch (err) {
+      console.error('Reply rewrite preview error:', err);
+      res.status(500).json({ success: false, message: 'AI 改寫失敗，請稍後再試' });
+    }
+  }
+);
+
 // Mark an inbound message as read
 router.put(
   '/:id/messages/:msgId/read',

--- a/routes/intimacy-requests.js
+++ b/routes/intimacy-requests.js
@@ -873,9 +873,9 @@ router.get('/notifications', async (req, res) => {
 
     // Check if notifications table exists, if not create it
     const result = await db.query(`
-      SELECT 
+      SELECT
         n.id, n.notification_type, n.title, n.content,
-        n.intimacy_request_id, n.is_read, n.read_at,
+        n.intimacy_request_id, n.event_id, n.is_read, n.read_at,
         n.created_at, n.priority,
         related_user.nickname as related_user_nickname
       FROM notifications n
@@ -925,6 +925,7 @@ router.get('/notifications', async (req, res) => {
       title: row.title,
       content: row.content,
       intimacy_request_id: row.intimacy_request_id,
+      event_id: row.event_id,
       related_user_nickname: row.related_user_nickname,
       is_read: row.is_read,
       read_at: row.read_at,

--- a/routes/intimacy-requests.js
+++ b/routes/intimacy-requests.js
@@ -863,13 +863,30 @@ router.get('/alternative-intimacy-options', async (req, res) => {
   }
 });
 
+// Ensure-on-first-call: the `event_id` column was added later for the events
+// × 破冰 deep-link. Older deployments may not have it yet, and the events
+// route only adds it when an event is actually created. Run an idempotent
+// ALTER once per process so the SELECT below doesn't 500.
+let notificationsEventIdEnsured = false;
+async function ensureNotificationsEventIdColumn() {
+  if (notificationsEventIdEnsured) return;
+  try {
+    await db.query(`ALTER TABLE notifications ADD COLUMN IF NOT EXISTS event_id UUID`);
+    notificationsEventIdEnsured = true;
+  } catch (err) {
+    console.warn('⚠️ ensureNotificationsEventIdColumn failed:', err.message);
+  }
+}
+
 // Get notifications for user
 router.get('/notifications', async (req, res) => {
   try {
     const userId = req.user.id;
     const { notification_type, is_read, limit = 50, offset = 0 } = req.query;
-    
+
     console.info(`🔔 Getting notifications for user ${userId} - type: ${notification_type || 'all'}, read: ${is_read}, limit: ${limit}`);
+
+    await ensureNotificationsEventIdColumn();
 
     // Check if notifications table exists, if not create it
     const result = await db.query(`
@@ -898,6 +915,7 @@ router.get('/notifications', async (req, res) => {
             title VARCHAR(200) NOT NULL,
             content TEXT NOT NULL,
             intimacy_request_id UUID REFERENCES intimacy_requests(id) ON DELETE CASCADE,
+            event_id UUID,
             related_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
             is_read BOOLEAN NOT NULL DEFAULT FALSE,
             read_at TIMESTAMP WITH TIME ZONE,

--- a/services/llm/claudeProvider.js
+++ b/services/llm/claudeProvider.js
@@ -129,6 +129,64 @@ const TOOL_SCHEMA = {
   },
 };
 
+const REPLY_REWRITE_SYSTEM_PROMPT = `你是一個專為情侶設計的「破冰」AI 助手。在這個任務中，使用者正在回覆伴侶開啟的事件（一段已被整理過的衝突描述）。使用者剛打了一段回覆，但情緒可能還沒整理好。請永遠以繁體中文回覆。
+
+任務：閱讀事件背景、最近對話、以及使用者寫好的原始回覆，產生三種風格的改寫版本，幫使用者把要送出去的訊息變得更中性、客觀、公平 — 但仍然保留使用者真實的立場與感受，不替伴侶辯護，也不替使用者道歉到失去自己。
+
+回應請呼叫 emit_reply_rewrite tool，產生：
+1. versions.neutral：第三方中性版。完全不示弱、不指責，以客觀方式描述使用者觀察到的事實與感受，1–3 句。
+2. versions.firm：堅定不攻擊版。以「我訊息」說出感受與影響，不指責、不請求、不討好，1–3 句。
+3. versions.warm：善意版。在 firm 的基礎上多一句願意聊聊、願意理解對方的善意，總長 2–4 句。
+4. toxicityFlags：偵測到的問題語言（同 icebreaker 任務的清單）。
+
+所有版本都必須：
+- 移除人身攻擊（笨/蠢/廢物 等）與絕對化用語（總是/從來/每次 等）；如果原文有，將其改寫為具體事實描述。
+- 不要強迫使用者道歉、不要替對方解釋，只是讓表達更乾淨。
+- 使用繁體中文。
+- 緊扣事件背景與原始回覆 — 不要編造新的細節。
+
+回應請只呼叫 emit_reply_rewrite tool，不要輸出其他文字。`;
+
+const REPLY_REWRITE_TOOL_SCHEMA = {
+  name: 'emit_reply_rewrite',
+  description: 'Return three rewritten versions of the user\'s reply.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      versions: {
+        type: 'object',
+        properties: {
+          neutral: { type: 'string' },
+          firm: { type: 'string' },
+          warm: { type: 'string' },
+        },
+        required: ['neutral', 'firm', 'warm'],
+      },
+      toxicityFlags: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: [
+            'absolute_language',
+            'name_calling',
+            'verbal_aggression',
+            'contempt',
+            'threats',
+            'blame_shifting',
+            'emotional_blackmail',
+            'sarcasm',
+            'catastrophizing',
+            'comparison',
+            'stonewalling',
+            'dismissiveness',
+          ],
+        },
+      },
+    },
+    required: ['versions', 'toxicityFlags'],
+  },
+};
+
 async function generateIcebreaker(rawText) {
   if (typeof rawText !== 'string' || rawText.trim().length === 0) {
     throw new Error('rawText is required');
@@ -180,4 +238,65 @@ async function generateIcebreaker(rawText) {
   };
 }
 
-module.exports = { generateIcebreaker };
+async function rewriteReply({ rawReply, eventSummary, recentMessages }) {
+  if (typeof rawReply !== 'string' || rawReply.trim().length === 0) {
+    throw new Error('rawReply is required');
+  }
+
+  const contextLines = [];
+  if (eventSummary && typeof eventSummary === 'string') {
+    contextLines.push(`事件背景摘要：${eventSummary.trim()}`);
+  }
+  if (Array.isArray(recentMessages) && recentMessages.length > 0) {
+    contextLines.push('最近對話（最舊在前）：');
+    for (const m of recentMessages) {
+      const who = m.fromSelf ? '我' : '伴侶';
+      contextLines.push(`- ${who}：${(m.content || '').trim()}`);
+    }
+  }
+  contextLines.push(`原始回覆：${rawReply.trim()}`);
+  const userContent = contextLines.join('\n');
+
+  const startedAt = Date.now();
+  const response = await getClient().messages.create({
+    model: MODEL,
+    max_tokens: 1024,
+    system: [
+      {
+        type: 'text',
+        text: REPLY_REWRITE_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    tools: [REPLY_REWRITE_TOOL_SCHEMA],
+    tool_choice: { type: 'tool', name: 'emit_reply_rewrite' },
+    messages: [{ role: 'user', content: userContent }],
+  });
+
+  const ms = Date.now() - startedAt;
+  const u = response.usage || {};
+  const cost = estimateCostUSD(response.model || MODEL, u);
+  const costStr = cost == null ? 'cost=unknown' : `~$${cost.toFixed(6)}`;
+  console.log(
+    `[llm.claude] reply_rewrite model=${response.model || MODEL} ${ms}ms ` +
+      `in=${u.input_tokens || 0} out=${u.output_tokens || 0} ` +
+      `cache_w=${u.cache_creation_input_tokens || 0} cache_r=${u.cache_read_input_tokens || 0} ${costStr}`
+  );
+
+  const toolUse = response.content.find((b) => b.type === 'tool_use' && b.name === 'emit_reply_rewrite');
+  if (!toolUse) {
+    throw new Error('Claude did not return a tool_use block');
+  }
+  const out = toolUse.input;
+
+  return {
+    versions: {
+      neutral: out.versions?.neutral || '',
+      firm: out.versions?.firm || '',
+      warm: out.versions?.warm || '',
+    },
+    toxicityFlags: out.toxicityFlags || [],
+  };
+}
+
+module.exports = { generateIcebreaker, rewriteReply };

--- a/services/llm/mockProvider.js
+++ b/services/llm/mockProvider.js
@@ -110,4 +110,21 @@ async function generateIcebreaker(rawText /* , context */) {
   return { title, summary, emotions, tags, toxicityFlags, versions };
 }
 
-module.exports = { generateIcebreaker };
+function buildReplyVersions(rawReply) {
+  const masked = maskToxicWords(rawReply.trim());
+  const neutral = `就剛剛的事，我這邊看到的是：${masked} 想先把這個放出來。`;
+  const firm = `我這邊的感受是：${masked} 我不是要指責，只是想讓你知道我的想法。`;
+  const warm = `${firm} 也想聽你的角度，等彼此都比較平靜時我們再聊。`;
+  return { neutral, firm, warm };
+}
+
+async function rewriteReply({ rawReply /* , eventSummary, recentMessages */ }) {
+  if (typeof rawReply !== 'string' || rawReply.trim().length === 0) {
+    throw new Error('rawReply is required');
+  }
+  const toxicityFlags = detectToxicity(rawReply);
+  const versions = buildReplyVersions(rawReply);
+  return { versions, toxicityFlags };
+}
+
+module.exports = { generateIcebreaker, rewriteReply };

--- a/services/llmService.js
+++ b/services/llmService.js
@@ -15,5 +15,6 @@ try {
 
 module.exports = {
   generateIcebreaker: provider.generateIcebreaker,
+  rewriteReply: provider.rewriteReply,
   providerName: PROVIDER_NAME,
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import IntimacyRequestForm from './components/IntimacyRequestForm';
 import NotificationInbox from './components/NotificationInbox';
 import PairingInvitationHandler from './components/PairingInvitationHandler';
 import { apiService } from './services/api';
+import { conflictPhraseTiers } from './data/conflictSteps';
 
 interface IntimateRecord {
   id: number;
@@ -384,6 +385,7 @@ interface PositionSuggestion {
 
 const LoveTimeApp = () => {
   const [currentView, setCurrentView] = useState('record');
+  const [pendingEventId, setPendingEventId] = useState<string | null>(null);
   const [intimateRecords, setIntimateRecords] = useState<IntimateRecord[]>([]);
   const [nicknames, setNicknames] = useState<Nicknames>({ partner1: '親愛的', partner2: '寶貝' });
 
@@ -2359,142 +2361,6 @@ const LoveTimeApp = () => {
         label: '快爆了',
         sub: '撐不住了',
         phrase: '我快撐不住了，我需要先暫停喘口氣，這不是不想處理，是先讓自己冷靜。',
-      },
-    ];
-
-    // Partner-facing guide — 8 small steps your partner can take when you're upset.
-    // Reframed from "what I say to defuse" to "what TA can do/say to bring me back."
-    // Each step has a phrase set the user can send to their partner.
-    const conflictPhraseTiers: {
-      key: string;
-      dot: string;
-      badge: string;
-      title: string;
-      why: string;
-      cardClass: string;
-      badgeClass: string;
-      phrases: string[];
-      note: string;
-    }[] = [
-      {
-        key: 'pause',
-        dot: '①',
-        badge: '先停一下',
-        title: '先停下來，不要反擊、不要解釋',
-        why: '我在情緒裡時真的聽不進去，越解釋我越受傷。先別急著講道理、辯解或繼續講你的觀點。',
-        cardClass: 'bg-sky-50/60 border-sky-200',
-        badgeClass: 'text-sky-800 bg-sky-100/80',
-        phrases: [
-          '好，我先停一下。我想理解你的感受。',
-          '我知道你現在不舒服，我先陪你。',
-          '我們不急著講完，我先聽你。',
-        ],
-        note: '你越快停下，我越快冷靜 — 這是降溫的第一步。',
-      },
-      {
-        key: 'acknowledge',
-        dot: '②',
-        badge: '承認情緒',
-        title: '用一句話承認我的情緒',
-        why: '一句話就能讓我冷靜一半。我不是要你認錯，是要你讓我覺得：你「有看見我」。',
-        cardClass: 'bg-amber-50/70 border-amber-200',
-        badgeClass: 'text-amber-900 bg-amber-100/80',
-        phrases: [
-          '我知道我剛剛的話讓你受傷了。',
-          '我看得出來你現在不開心。',
-          '對，我的語氣太急了，我懂。',
-        ],
-        note: '被看見，比被解釋更能讓我放下武裝。',
-      },
-      {
-        key: 'soften',
-        dot: '③',
-        badge: '語氣放軟',
-        title: '語氣放軟，用溫柔代替強硬',
-        why: '內容可以一樣，但語氣要軟很多。我對情緒很敏感 — 語氣比內容還重要。',
-        cardClass: 'bg-rose-50/60 border-rose-200',
-        badgeClass: 'text-rose-800 bg-rose-100/80',
-        phrases: [
-          '你先別急，我在這裡。',
-          '寶貝，我不是對你生氣。',
-          '我想先照顧你的感受，事情等等再說。',
-        ],
-        note: '同一句話，溫柔說 — 是完全不一樣的訊息。',
-      },
-      {
-        key: 'soothe',
-        dot: '④',
-        badge: '輕輕安撫',
-        title: '給我一點點安撫 — 肢體或語言都好',
-        why: '不一定要抱我，但一個輕柔的動作能讓我安心很多。',
-        cardClass: 'bg-violet-50/60 border-violet-200',
-        badgeClass: 'text-violet-800 bg-violet-100/80',
-        phrases: [
-          '我在，你先呼吸一下。',
-          '我牽你的手，好嗎？',
-          '讓我抱你一下，不用說話也可以。',
-        ],
-        note: '一個小動作，常常比一千句解釋還有效。',
-      },
-      {
-        key: 'reassure',
-        dot: '⑤',
-        badge: '給我保證',
-        title: '保證一下：不是要吵架，是希望彼此更好',
-        why: '一句保證，能讓我從戒備狀態裡放下來。',
-        cardClass: 'bg-emerald-50/60 border-emerald-200',
-        badgeClass: 'text-emerald-800 bg-emerald-100/80',
-        phrases: [
-          '我不是要跟你吵，我想靠近你。',
-          '我希望我們是一起的，不是對立的。',
-          '我想先把你的情緒接住，事情等等再談。',
-        ],
-        note: '把方向定清楚 — 我們是同一隊，不是敵人。',
-      },
-      {
-        key: 'step-down',
-        dot: '⑥',
-        badge: '給我台階',
-        title: '給我一個台階 — 讓我知道你願意等',
-        why: '有台階，我就會回頭。沒有台階，我只會越走越遠。',
-        cardClass: 'bg-orange-50/60 border-orange-200',
-        badgeClass: 'text-orange-800 bg-orange-100/80',
-        phrases: [
-          '你先休息一下，等你準備好我就在這裡。',
-          '你想等 10 分鐘再聊，還是等到我們都冷靜？',
-          '你先慢慢來，我陪你。',
-        ],
-        note: '願意等，比逼著解決更能打開門。',
-      },
-      {
-        key: 'tender',
-        dot: '⑦',
-        badge: '撒嬌靠近',
-        title: '撒嬌一點、軟軟地靠近我',
-        why: '這對你來說可能很小，但對我來說常常是最有效的。',
-        cardClass: 'bg-pink-50/60 border-pink-200',
-        badgeClass: 'text-pink-800 bg-pink-100/80',
-        phrases: [
-          '我也會怕你生氣，我很在意你。',
-          '我想你了，過來一下嘛。',
-          '我希望你被我好好愛著。',
-        ],
-        note: '硬碰硬會兩敗俱傷 — 軟下來的人，才贏。',
-      },
-      {
-        key: 'affirm',
-        dot: '⑧',
-        badge: '溫柔收尾',
-        title: '等我冷下來，用一句肯定句收尾',
-        why: '不要急著講道理或立場，先肯定我 — 我才真的有辦法聽進你的想法。',
-        cardClass: 'bg-stone-50 border-stone-300',
-        badgeClass: 'text-stone-800 bg-stone-200/70',
-        phrases: [
-          '你對我很重要。',
-          '我希望你每天都很安心。',
-          '我很愛你，我不想你難過。',
-        ],
-        note: '先給情緒一個落腳的地方，事情再來談。',
       },
     ];
 
@@ -5167,7 +5033,14 @@ const LoveTimeApp = () => {
       case 'games':
         return <GamesView />;
       case 'conflict': return <ConflictView />;
-      case 'events': return <EventsView authState={authState} showNotification={showNotification} />;
+      case 'events': return (
+        <EventsView
+          authState={authState}
+          showNotification={showNotification}
+          initialEventId={pendingEventId}
+          onInitialEventConsumed={() => setPendingEventId(null)}
+        />
+      );
       case 'roleplay': return <RoleplayView
         defaultRoleplayScripts={defaultRoleplayScripts}
         customScripts={customScripts}
@@ -5522,7 +5395,12 @@ const LoveTimeApp = () => {
         onClose={() => setShowNotificationInbox(false)}
         unreadCount={unreadNotificationCount}
         onUnreadCountChange={setUnreadNotificationCount}
-        onNavigate={setCurrentView}
+        onNavigate={(view, payload) => {
+          if (view === 'events' && payload) {
+            setPendingEventId(payload);
+          }
+          setCurrentView(view);
+        }}
       />
 
       {/* Record Detail Modal */}

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -7,8 +7,16 @@ import {
   Tag,
   Loader2,
   Lock,
+  Sparkles,
+  X,
 } from 'lucide-react';
-import apiService, { type EventRecord, type EventStatus } from '../services/api';
+import apiService, {
+  type EventRecord,
+  type EventStatus,
+  type ReplyRewritePreview,
+  type EventVersionKey,
+} from '../services/api';
+import ReplyStepBar from './ReplyStepBar';
 
 interface NotificationInput {
   type: 'success' | 'error' | 'info' | 'warning';
@@ -66,6 +74,36 @@ export default function EventDetail({ eventId, currentUserId, onBack, showNotifi
   const [reply, setReply] = useState('');
   const [sending, setSending] = useState(false);
   const [resolving, setResolving] = useState(false);
+  const [rewriting, setRewriting] = useState(false);
+  const [rewritePreview, setRewritePreview] = useState<ReplyRewritePreview | null>(null);
+
+  const insertPhrase = (phrase: string) => {
+    setReply((prev) => (prev.trim().length > 0 ? `${prev}\n${phrase}` : phrase));
+  };
+
+  const requestRewrite = async () => {
+    const draft = reply.trim();
+    if (!draft) return;
+    setRewriting(true);
+    try {
+      const preview = await apiService.previewReplyRewrite(eventId, draft);
+      setRewritePreview(preview);
+    } catch (err) {
+      showNotification({
+        type: 'error',
+        title: 'AI 改寫失敗',
+        message: err instanceof Error ? err.message : '請稍後再試',
+      });
+    } finally {
+      setRewriting(false);
+    }
+  };
+
+  const applyRewriteVersion = (key: EventVersionKey) => {
+    if (!rewritePreview) return;
+    setReply(rewritePreview.versions[key]);
+    setRewritePreview(null);
+  };
 
   const refresh = async () => {
     try {
@@ -227,7 +265,9 @@ export default function EventDetail({ eventId, currentUserId, onBack, showNotifi
 
       {canSendMessage && (
         <div className="bg-petal-cream border border-petal-rule rounded-2xl p-3">
+          <ReplyStepBar onInsertPhrase={insertPhrase} />
           <textarea
+            data-testid="event-reply-input"
             value={reply}
             onChange={(e) => setReply(e.target.value)}
             placeholder="回覆…"
@@ -235,9 +275,21 @@ export default function EventDetail({ eventId, currentUserId, onBack, showNotifi
             maxLength={2000}
             className="w-full p-2 rounded-xl border border-petal-rule bg-white text-petal-ink placeholder:text-petal-muted focus:outline-none focus:border-petal-rose-deep resize-y"
           />
-          <div className="flex justify-end mt-2">
+          <div className="flex flex-wrap justify-end gap-2 mt-2">
             <button
               type="button"
+              data-testid="event-reply-rewrite-button"
+              onClick={requestRewrite}
+              disabled={rewriting || reply.trim().length === 0}
+              className="px-3 py-2 rounded-full border border-petal-sage text-petal-ink inline-flex items-center gap-2 disabled:opacity-50 hover:bg-petal-sage/20"
+              title="讓 AI 把你的回覆改得更中性、客觀"
+            >
+              {rewriting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
+              <span>讓 AI 重寫</span>
+            </button>
+            <button
+              type="button"
+              data-testid="event-reply-send-button"
               onClick={sendReply}
               disabled={sending || reply.trim().length === 0}
               className="px-4 py-2 rounded-full bg-petal-ink text-petal-cream inline-flex items-center gap-2 disabled:opacity-50"
@@ -247,6 +299,14 @@ export default function EventDetail({ eventId, currentUserId, onBack, showNotifi
             </button>
           </div>
         </div>
+      )}
+
+      {rewritePreview && (
+        <RewritePicker
+          preview={rewritePreview}
+          onApply={applyRewriteVersion}
+          onCancel={() => setRewritePreview(null)}
+        />
       )}
 
       {!event.isPrivate && event.status !== 'resolved' && (
@@ -326,5 +386,81 @@ function BackButton({ onBack }: { onBack: () => void }) {
       <ArrowLeft className="w-4 h-4" />
       回到歷史
     </button>
+  );
+}
+
+const VERSION_LABELS: Record<EventVersionKey, { title: string; hint: string }> = {
+  neutral: { title: '中性版', hint: '第三方客觀描述，不示弱也不指責' },
+  firm: { title: '堅定版', hint: '以「我訊息」說感受，不指責' },
+  warm: { title: '善意版', hint: '在堅定的基礎上多一份願意聊聊的善意' },
+};
+
+function RewritePicker({
+  preview,
+  onApply,
+  onCancel,
+}: {
+  preview: ReplyRewritePreview;
+  onApply: (key: EventVersionKey) => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+      data-testid="event-reply-rewrite-modal"
+    >
+      <div className="bg-petal-cream rounded-2xl max-w-lg w-full max-h-[85vh] overflow-y-auto p-5">
+        <div className="flex items-start justify-between mb-3">
+          <div>
+            <h3 className="text-lg font-serif text-petal-ink">AI 幫你改寫的版本</h3>
+            <p className="text-xs text-petal-ink-soft mt-1">挑一個版本套用到你的草稿，或保留原文。</p>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-petal-ink-soft hover:text-petal-ink"
+            aria-label="取消"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {(Object.keys(VERSION_LABELS) as EventVersionKey[]).map((key) => (
+            <div
+              key={key}
+              className="bg-white border border-petal-rule rounded-xl p-3"
+              data-testid={`event-reply-rewrite-card-${key}`}
+            >
+              <div className="flex items-baseline justify-between mb-1">
+                <div className="text-sm font-medium text-petal-ink">{VERSION_LABELS[key].title}</div>
+                <div className="text-[11px] text-petal-muted">{VERSION_LABELS[key].hint}</div>
+              </div>
+              <p className="text-sm text-petal-ink whitespace-pre-wrap mb-2">{preview.versions[key]}</p>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  data-testid={`event-reply-rewrite-apply-${key}`}
+                  onClick={() => onApply(key)}
+                  className="text-sm px-3 py-1.5 rounded-full bg-petal-ink text-petal-cream hover:opacity-90"
+                >
+                  使用這個版本
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex justify-end mt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-sm px-4 py-2 rounded-full border border-petal-rule text-petal-ink hover:bg-petal-sage/20"
+          >
+            保留原文
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/components/EventsView.tsx
+++ b/src/components/EventsView.tsx
@@ -23,9 +23,16 @@ interface NotificationInput {
 interface EventsViewProps {
   authState: AuthState;
   showNotification: (notification: NotificationInput) => void;
+  initialEventId?: string | null;
+  onInitialEventConsumed?: () => void;
 }
 
-export default function EventsView({ authState, showNotification }: EventsViewProps) {
+export default function EventsView({
+  authState,
+  showNotification,
+  initialEventId,
+  onInitialEventConsumed,
+}: EventsViewProps) {
   const [view, setView] = useState<EventsSubView>('list');
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -33,6 +40,17 @@ export default function EventsView({ authState, showNotification }: EventsViewPr
   useEffect(() => {
     if (view !== 'detail') setSelectedEventId(null);
   }, [view]);
+
+  // When the parent passes an initialEventId (e.g. from a notification tap),
+  // jump straight to detail. Clear the parent's pending id so re-mounting the
+  // view later doesn't reopen the same event.
+  useEffect(() => {
+    if (initialEventId) {
+      setSelectedEventId(initialEventId);
+      setView('detail');
+      onInitialEventConsumed?.();
+    }
+  }, [initialEventId, onInitialEventConsumed]);
 
   const openDetail = (id: string) => {
     setSelectedEventId(id);

--- a/src/components/NotificationInbox.tsx
+++ b/src/components/NotificationInbox.tsx
@@ -23,7 +23,7 @@ interface NotificationInboxProps {
   onClose: () => void;
   unreadCount: number;
   onUnreadCountChange: (count: number) => void;
-  onNavigate?: (view: string) => void;
+  onNavigate?: (view: string, payload?: string) => void;
 }
 
 const NotificationInbox: React.FC<NotificationInboxProps> = ({
@@ -102,6 +102,13 @@ const NotificationInbox: React.FC<NotificationInboxProps> = ({
     ) {
       if (onNavigate) {
         onNavigate('wall');
+        onClose();
+      }
+      return;
+    }
+    if (notification.notificationType === 'event_created' && notification.eventId) {
+      if (onNavigate) {
+        onNavigate('events', notification.eventId);
         onClose();
       }
       return;
@@ -385,6 +392,7 @@ const NotificationInbox: React.FC<NotificationInboxProps> = ({
                 notifications.map((notification) => (
                   <div
                     key={notification.id}
+                    data-testid={`notification-item-${notification.notificationType}`}
                     className={`p-4 hover:bg-gray-50 transition-colors cursor-pointer ${
                       !notification.isRead ? 'bg-blue-50' : ''
                     }`}

--- a/src/components/ReplyStepBar.tsx
+++ b/src/components/ReplyStepBar.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { conflictPhraseTiers, type ConflictStep } from '../data/conflictSteps';
+
+interface ReplyStepBarProps {
+  onInsertPhrase: (phrase: string) => void;
+}
+
+// Compact step-bar that surfaces the 8-step conflict-resolution guide above the
+// reply textarea. Tap a step pill → reveals its 3 sample phrases + a short
+// "why" note. Tap a phrase → inserts it into the textarea via the parent.
+export default function ReplyStepBar({ onInsertPhrase }: ReplyStepBarProps) {
+  const [openKey, setOpenKey] = useState<string | null>(null);
+
+  const openStep: ConflictStep | undefined = openKey
+    ? conflictPhraseTiers.find((s) => s.key === openKey)
+    : undefined;
+
+  return (
+    <div className="mb-3" data-testid="reply-step-bar">
+      <div className="text-xs text-petal-ink-soft mb-1.5">不確定怎麼回？先看看建議的步驟：</div>
+      <div className="flex flex-wrap gap-1.5">
+        {conflictPhraseTiers.map((step) => {
+          const isOpen = openKey === step.key;
+          return (
+            <button
+              key={step.key}
+              type="button"
+              data-testid={`reply-step-pill-${step.key}`}
+              onClick={() => setOpenKey(isOpen ? null : step.key)}
+              className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                isOpen
+                  ? 'bg-petal-ink text-petal-cream border-petal-ink'
+                  : 'bg-white text-petal-ink border-petal-rule hover:bg-petal-sage/20'
+              }`}
+            >
+              <span className="mr-1">{step.dot}</span>
+              {step.badge}
+            </button>
+          );
+        })}
+      </div>
+
+      {openStep && (
+        <div
+          className={`mt-2 p-3 rounded-xl border ${openStep.cardClass}`}
+          data-testid={`reply-step-panel-${openStep.key}`}
+        >
+          <div className="text-sm font-medium text-petal-ink mb-1">{openStep.title}</div>
+          <div className="text-xs text-petal-ink-soft mb-2">{openStep.why}</div>
+          <div className="flex flex-col gap-1.5">
+            {openStep.phrases.map((phrase) => (
+              <button
+                key={phrase}
+                type="button"
+                data-testid={`reply-step-phrase`}
+                onClick={() => {
+                  onInsertPhrase(phrase);
+                  setOpenKey(null);
+                }}
+                className="text-left text-sm px-3 py-1.5 rounded-lg bg-white/70 border border-white text-petal-ink hover:bg-white"
+              >
+                {phrase}
+              </button>
+            ))}
+          </div>
+          <div className="text-xs text-petal-ink-soft mt-2 italic">{openStep.note}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data/conflictSteps.ts
+++ b/src/data/conflictSteps.ts
@@ -1,0 +1,138 @@
+// 8-step partner guide used by ConflictView (the standalone "和解步驟" page)
+// and by the reply composer inside an event thread. Each step has 3 sample
+// phrases the upset partner can tap to insert into their reply.
+
+export interface ConflictStep {
+  key: string;
+  dot: string;
+  badge: string;
+  title: string;
+  why: string;
+  cardClass: string;
+  badgeClass: string;
+  phrases: string[];
+  note: string;
+}
+
+export const conflictPhraseTiers: ConflictStep[] = [
+  {
+    key: 'pause',
+    dot: '①',
+    badge: '先停一下',
+    title: '先停下來，不要反擊、不要解釋',
+    why: '我在情緒裡時真的聽不進去，越解釋我越受傷。先別急著講道理、辯解或繼續講你的觀點。',
+    cardClass: 'bg-sky-50/60 border-sky-200',
+    badgeClass: 'text-sky-800 bg-sky-100/80',
+    phrases: [
+      '好，我先停一下。我想理解你的感受。',
+      '我知道你現在不舒服，我先陪你。',
+      '我們不急著講完，我先聽你。',
+    ],
+    note: '你越快停下，我越快冷靜 — 這是降溫的第一步。',
+  },
+  {
+    key: 'acknowledge',
+    dot: '②',
+    badge: '承認情緒',
+    title: '用一句話承認我的情緒',
+    why: '一句話就能讓我冷靜一半。我不是要你認錯，是要你讓我覺得：你「有看見我」。',
+    cardClass: 'bg-amber-50/70 border-amber-200',
+    badgeClass: 'text-amber-900 bg-amber-100/80',
+    phrases: [
+      '我知道我剛剛的話讓你受傷了。',
+      '我看得出來你現在不開心。',
+      '對，我的語氣太急了，我懂。',
+    ],
+    note: '被看見，比被解釋更能讓我放下武裝。',
+  },
+  {
+    key: 'soften',
+    dot: '③',
+    badge: '語氣放軟',
+    title: '語氣放軟，用溫柔代替強硬',
+    why: '內容可以一樣，但語氣要軟很多。我對情緒很敏感 — 語氣比內容還重要。',
+    cardClass: 'bg-rose-50/60 border-rose-200',
+    badgeClass: 'text-rose-800 bg-rose-100/80',
+    phrases: [
+      '你先別急，我在這裡。',
+      '寶貝，我不是對你生氣。',
+      '我想先照顧你的感受，事情等等再說。',
+    ],
+    note: '同一句話，溫柔說 — 是完全不一樣的訊息。',
+  },
+  {
+    key: 'soothe',
+    dot: '④',
+    badge: '輕輕安撫',
+    title: '給我一點點安撫 — 肢體或語言都好',
+    why: '不一定要抱我，但一個輕柔的動作能讓我安心很多。',
+    cardClass: 'bg-violet-50/60 border-violet-200',
+    badgeClass: 'text-violet-800 bg-violet-100/80',
+    phrases: [
+      '我在，你先呼吸一下。',
+      '我牽你的手，好嗎？',
+      '讓我抱你一下，不用說話也可以。',
+    ],
+    note: '一個小動作，常常比一千句解釋還有效。',
+  },
+  {
+    key: 'reassure',
+    dot: '⑤',
+    badge: '給我保證',
+    title: '保證一下：不是要吵架，是希望彼此更好',
+    why: '一句保證，能讓我從戒備狀態裡放下來。',
+    cardClass: 'bg-emerald-50/60 border-emerald-200',
+    badgeClass: 'text-emerald-800 bg-emerald-100/80',
+    phrases: [
+      '我不是要跟你吵，我想靠近你。',
+      '我希望我們是一起的，不是對立的。',
+      '我想先把你的情緒接住，事情等等再談。',
+    ],
+    note: '把方向定清楚 — 我們是同一隊，不是敵人。',
+  },
+  {
+    key: 'step-down',
+    dot: '⑥',
+    badge: '給我台階',
+    title: '給我一個台階 — 讓我知道你願意等',
+    why: '有台階，我就會回頭。沒有台階，我只會越走越遠。',
+    cardClass: 'bg-orange-50/60 border-orange-200',
+    badgeClass: 'text-orange-800 bg-orange-100/80',
+    phrases: [
+      '你先休息一下，等你準備好我就在這裡。',
+      '你想等 10 分鐘再聊，還是等到我們都冷靜？',
+      '你先慢慢來，我陪你。',
+    ],
+    note: '願意等，比逼著解決更能打開門。',
+  },
+  {
+    key: 'tender',
+    dot: '⑦',
+    badge: '撒嬌靠近',
+    title: '撒嬌一點、軟軟地靠近我',
+    why: '這對你來說可能很小，但對我來說常常是最有效的。',
+    cardClass: 'bg-pink-50/60 border-pink-200',
+    badgeClass: 'text-pink-800 bg-pink-100/80',
+    phrases: [
+      '我也會怕你生氣，我很在意你。',
+      '我想你了，過來一下嘛。',
+      '我希望你被我好好愛著。',
+    ],
+    note: '硬碰硬會兩敗俱傷 — 軟下來的人，才贏。',
+  },
+  {
+    key: 'affirm',
+    dot: '⑧',
+    badge: '溫柔收尾',
+    title: '等我冷下來，用一句肯定句收尾',
+    why: '不要急著講道理或立場，先肯定我 — 我才真的有辦法聽進你的想法。',
+    cardClass: 'bg-stone-50 border-stone-300',
+    badgeClass: 'text-stone-800 bg-stone-200/70',
+    phrases: [
+      '你對我很重要。',
+      '我希望你每天都很安心。',
+      '我很愛你，我不想你難過。',
+    ],
+    note: '先給情緒一個落腳的地方，事情再來談。',
+  },
+];

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -212,6 +212,7 @@ interface Notification {
   title: string;
   content: string;
   intimacyRequestId?: string;
+  eventId?: string;
   relatedUserNickname?: string;
   isRead: boolean;
   readAt?: string;
@@ -236,6 +237,11 @@ export interface IcebreakerPreview {
   tags: string[];
   toxicityFlags: string[];
   versions: EventVersions;
+}
+
+export interface ReplyRewritePreview {
+  versions: EventVersions;
+  toxicityFlags: string[];
 }
 
 export interface EventMessage {
@@ -1496,6 +1502,7 @@ class ApiService {
       title?: string;
       content?: string;
       intimacy_request_id?: string;
+      event_id?: string;
       related_user_nickname?: string;
       is_read?: boolean;
       read_at?: string;
@@ -1509,6 +1516,7 @@ class ApiService {
       title: typedData?.title || '',
       content: typedData?.content || '',
       intimacyRequestId: typedData?.intimacy_request_id,
+      eventId: typedData?.event_id,
       relatedUserNickname: typedData?.related_user_nickname,
       isRead: typedData?.is_read || false,
       readAt: typedData?.read_at,
@@ -1612,6 +1620,24 @@ class ApiService {
     } catch (error: unknown) {
       console.error('Failed to reply to event:', error);
       this.throwApiError(error, '無法送出訊息');
+    }
+  }
+
+  async previewReplyRewrite(eventId: string, rawReply: string): Promise<ReplyRewritePreview> {
+    try {
+      const response = await apiClient.post(`/events/${eventId}/messages/preview-rewrite`, { rawReply });
+      const p = response.data.preview ?? {};
+      return {
+        versions: {
+          neutral: p.versions?.neutral || '',
+          firm: p.versions?.firm || '',
+          warm: p.versions?.warm || '',
+        },
+        toxicityFlags: Array.isArray(p.toxicityFlags) ? p.toxicityFlags : [],
+      };
+    } catch (error: unknown) {
+      console.error('Failed to preview reply rewrite:', error);
+      this.throwApiError(error, '無法改寫回覆，請稍後再試');
     }
   }
 

--- a/tests/events-reply.spec.ts
+++ b/tests/events-reply.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+
+// Smoke test for the event-reply step-bar + AI rewrite UI. We stub the auth
+// state and the events APIs so the test doesn't depend on a paired test
+// couple in the DB. The mock provider would normally power /preview-rewrite,
+// but we stub the response here too — the goal is to verify the UI flow,
+// not the LLM plumbing (that's covered by the provider unit shape).
+
+const FAKE_USER = { id: '11111111-1111-1111-1111-111111111111', email: 'a@x.test', nickname: 'A' };
+const FAKE_EVENT_ID = '22222222-2222-2222-2222-222222222222';
+
+const FAKE_EVENT = {
+  id: FAKE_EVENT_ID,
+  couple_id: '33333333-3333-3333-3333-333333333333',
+  created_by: '99999999-9999-9999-9999-999999999999', // partner — so the UI treats it as inbound
+  title: '今晚的家事',
+  summary: '對方覺得家事分配不公，希望聊聊。',
+  emotions: ['委屈'],
+  tags: ['家務'],
+  toxicity_flags: [],
+  versions: { neutral: '', firm: '', warm: '' },
+  selected_version: null,
+  is_private: false,
+  status: 'open',
+  resolve_requested_by: null,
+  resolve_requested_at: null,
+  resolved_at: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  messages: [],
+};
+
+test.describe('Event reply — step-bar and AI rewrite', () => {
+  test.beforeEach(async ({ page }) => {
+    // Pre-seed auth so the app loads as an authenticated + paired user.
+    await page.addInitScript((user) => {
+      localStorage.setItem('authToken', 'fake-jwt');
+      localStorage.setItem('authUser', JSON.stringify(user));
+      localStorage.setItem(
+        'authState',
+        JSON.stringify({ user, isAuthenticated: true, partnerConnected: true })
+      );
+      localStorage.setItem('pairingPromptDismissed', 'true');
+    }, FAKE_USER);
+
+    // Stub anything that might verify auth / re-fetch user state to keep
+    // the seeded localStorage authoritative.
+    await page.route('**/api/auth/**', async (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, user: FAKE_USER, partnerConnected: true }),
+        });
+      }
+      return route.continue();
+    });
+
+    // Stub the events list + detail + rewrite preview.
+    await page.route('**/api/events/**', async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (method === 'POST' && url.endsWith('/preview-rewrite')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            preview: {
+              versions: {
+                neutral: '中性版：我這邊看到家事分配的部分有點失衡，想一起看看怎麼安排。',
+                firm: '堅定版：我覺得目前的家事分配讓我有點累，希望我們可以一起調整。',
+                warm: '善意版：我有點累，希望我們可以一起聊聊家事的安排，也想聽你的想法。',
+              },
+              toxicityFlags: [],
+            },
+          }),
+        });
+      }
+
+      if (method === 'GET' && url.endsWith(`/api/events/${FAKE_EVENT_ID}`)) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, event: FAKE_EVENT }),
+        });
+      }
+
+      return route.continue();
+    });
+
+    await page.route('**/api/events*', async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+      // List endpoint — match `/api/events` or `/api/events?...` exactly (no trailing /...)
+      if (method === 'GET' && /\/api\/events(\?[^/]*)?$/.test(url)) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            events: [FAKE_EVENT],
+            total: 1,
+          }),
+        });
+      }
+      return route.continue();
+    });
+  });
+
+  test('insert sample phrase and run AI rewrite', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Navigate to events view directly via the deep-link state by tapping
+    // through the nav. The nav item id is 'events'. Use a generic locator.
+    const eventsNav = page.locator('button:has-text("事件")').first();
+    await eventsNav.waitFor({ state: 'visible', timeout: 15000 });
+    await eventsNav.click();
+
+    // Tap the (single) fake event in the history list.
+    const eventCard = page.locator(`text=今晚的家事`).first();
+    await eventCard.waitFor({ state: 'visible', timeout: 10000 });
+    await eventCard.click();
+
+    // Reply input should be visible now.
+    const replyInput = page.getByTestId('event-reply-input');
+    await replyInput.waitFor({ state: 'visible', timeout: 10000 });
+
+    // Step-bar: open step ② (承認情緒) and insert one of its phrases.
+    const stepPill = page.getByTestId('reply-step-pill-acknowledge');
+    await stepPill.click();
+    const firstPhrase = page.getByTestId('reply-step-phrase').first();
+    await firstPhrase.waitFor({ state: 'visible', timeout: 5000 });
+    await firstPhrase.click();
+
+    // Phrase should now be in the textarea.
+    await expect(replyInput).not.toHaveValue('');
+
+    // Trigger AI rewrite.
+    await page.getByTestId('event-reply-rewrite-button').click();
+
+    // Modal renders three version cards.
+    await expect(page.getByTestId('event-reply-rewrite-modal')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('event-reply-rewrite-card-neutral')).toBeVisible();
+    await expect(page.getByTestId('event-reply-rewrite-card-firm')).toBeVisible();
+    await expect(page.getByTestId('event-reply-rewrite-card-warm')).toBeVisible();
+
+    // Apply the neutral version — textarea should swap to it.
+    await page.getByTestId('event-reply-rewrite-apply-neutral').click();
+    await expect(page.getByTestId('event-reply-rewrite-modal')).toHaveCount(0);
+    await expect(replyInput).toHaveValue(/中性版：我這邊看到家事分配/);
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to the 事件 × 破冰 feature (PRs #28, #29). Closes two dogfooding gaps:

- **Notification deep-link**: tapping an `event_created` notification now jumps straight into the matching event detail. Backend already stored the `event_id`; only the wire-up was missing — surfaces it in the GET response, threads `pendingEventId` through `App` → `EventsView`, and adds the click branch in `NotificationInbox`.
- **Reply UI**: replies are no longer a raw textarea.
  - **Step-bar**: new `ReplyStepBar` shows the 8-step conflict-resolution guide (extracted from `App.tsx` into `src/data/conflictSteps.ts` so it's reusable). Tap a step → see 3 sample phrases + a short "why" → tap a phrase to insert as a starter line.
  - **AI rewrite**: new `讓 AI 重寫` button calls `POST /events/:id/messages/preview-rewrite` (stateless, mirrors `/icebreaker`). The Claude provider gains a dedicated system prompt + tool schema and per-call cost log; mockProvider gives a deterministic version for dev/CI. Modal renders neutral / firm / warm cards; pick one to replace the draft, or keep the original.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm run test:e2e` → 13/13 green in 23.7s (12 existing + 1 new `events-reply` smoke that drives the step-bar + AI rewrite UI via route mocking)
- [ ] Manual: log in as paired couple, A creates shared event, B taps notification → lands on EventDetail
- [ ] Manual: tap step ② phrase → appears in textarea; type heated reply → tap 讓 AI 重寫 → pick a version → send
- [ ] Verify server log line `[llm.claude] reply_rewrite ... ~$0.000xxx` per rewrite call

🤖 Generated with [Claude Code](https://claude.com/claude-code)