### PR TITLE
Move coin shop and settings to header menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5017,8 +5017,7 @@ const LoveTimeApp = () => {
     { id: 'roleplay', label: '角色扮演', icon: Play },
     { id: 'wall', label: '我們的牆', icon: StickyNote },
     { id: 'journey', label: '愛情旅程', icon: Trophy },
-    { id: 'intimacy-history', label: '訊息紀錄', icon: Inbox },
-    { id: 'settings', label: '設定', icon: Heart }
+    { id: 'intimacy-history', label: '訊息紀錄', icon: Inbox }
   ];
 
   const renderView = () => {
@@ -5252,6 +5251,7 @@ const LoveTimeApp = () => {
         onShowIntimacyRequest={() => setShowIntimacyRequestForm(true)}
         onShowNotifications={() => setShowNotificationInbox(true)}
         onShowCoinShop={() => setCurrentView('shop')}
+        onShowSettings={() => setCurrentView('settings')}
       />
       
       {/* Notification Container */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Heart, Calendar, Trophy, Gamepad2, MessageCircle, Clock, Sparkles, Camera, MapPin, Upload, Play, Coins, Plus, X, User, ShoppingBag, Inbox, Pause, StickyNote, ChevronDown, ChevronUp, Send, Check, MessageSquareHeart } from 'lucide-react';
+import { Heart, Calendar, Trophy, Gamepad2, MessageCircle, Clock, Sparkles, Camera, MapPin, Upload, Play, Coins, Plus, X, User, Inbox, Pause, StickyNote, ChevronDown, ChevronUp, Send, Check, MessageSquareHeart } from 'lucide-react';
 import SettingsView from './components/SettingsView';
 import RoleplayView from './components/RoleplayView';
 import WallView from './components/WallView';
@@ -5011,14 +5011,13 @@ const LoveTimeApp = () => {
 
   const navItems = [
     { id: 'record', label: '記錄時光', icon: Calendar },
-    { id: 'shop', label: '金幣商店', icon: ShoppingBag },
     { id: 'games', label: '情趣遊戲', icon: Gamepad2 },
     { id: 'conflict', label: '和諧相處', icon: MessageCircle },
     { id: 'events', label: '事件', icon: MessageSquareHeart },
     { id: 'roleplay', label: '角色扮演', icon: Play },
     { id: 'wall', label: '我們的牆', icon: StickyNote },
     { id: 'journey', label: '愛情旅程', icon: Trophy },
-    { id: 'intimacy-history', label: '邀請紀錄', icon: Inbox },
+    { id: 'intimacy-history', label: '訊息紀錄', icon: Inbox },
     { id: 'settings', label: '設定', icon: Heart }
   ];
 
@@ -5252,6 +5251,7 @@ const LoveTimeApp = () => {
         onLogout={handleLogout}
         onShowIntimacyRequest={() => setShowIntimacyRequestForm(true)}
         onShowNotifications={() => setShowNotificationInbox(true)}
+        onShowCoinShop={() => setCurrentView('shop')}
       />
       
       {/* Notification Container */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,15 +24,17 @@ interface HeaderProps {
   onLogout: () => void;
   onShowIntimacyRequest: () => void;
   onShowNotifications: () => void;
+  onShowCoinShop: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ 
-  authState, 
-  totalCoins, 
-  onShowAuthModal, 
+const Header: React.FC<HeaderProps> = ({
+  authState,
+  totalCoins,
+  onShowAuthModal,
   onLogout,
   onShowIntimacyRequest,
   onShowNotifications,
+  onShowCoinShop,
 }) => {
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
@@ -115,13 +117,15 @@ const Header: React.FC<HeaderProps> = ({
 
             {/* Coins Display */}
             {authState.isAuthenticated && (
-              <div
+              <button
+                onClick={onShowCoinShop}
                 data-testid="coin-balance"
-                className="flex items-center space-x-1.5 border border-petal-rule px-3 py-1.5 rounded-full"
+                title="前往金幣商店"
+                className="flex items-center space-x-1.5 border border-petal-rule hover:border-petal-ink px-3 py-1.5 rounded-full transition-colors"
               >
                 <Coins className="w-3.5 h-3.5 text-pink-600" strokeWidth={1.5} />
                 <span className="font-display italic text-sm text-petal-ink">{totalCoins}</span>
-              </div>
+              </button>
             )}
 
             {/* User Section */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { User, LogOut, Coins, Heart, Bell, Send } from 'lucide-react';
+import { User, LogOut, Coins, Heart, Bell, Send, Settings } from 'lucide-react';
 import { apiService } from '../services/api';
 
 interface User {
@@ -25,6 +25,7 @@ interface HeaderProps {
   onShowIntimacyRequest: () => void;
   onShowNotifications: () => void;
   onShowCoinShop: () => void;
+  onShowSettings: () => void;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -35,6 +36,7 @@ const Header: React.FC<HeaderProps> = ({
   onShowIntimacyRequest,
   onShowNotifications,
   onShowCoinShop,
+  onShowSettings,
 }) => {
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
@@ -164,6 +166,17 @@ const Header: React.FC<HeaderProps> = ({
                       )}
                     </div>
                     <div className="p-2">
+                      <button
+                        onClick={() => {
+                          onShowSettings();
+                          setShowUserMenu(false);
+                        }}
+                        data-testid="user-menu-settings"
+                        className="w-full flex items-center space-x-2 px-3 py-2 font-body text-sm text-petal-ink-soft hover:bg-petal-cream-2 rounded-md transition-colors"
+                      >
+                        <Settings className="w-3.5 h-3.5" strokeWidth={1.5} />
+                        <span>設定</span>
+                      </button>
                       <button
                         onClick={handleLogout}
                         className="w-full flex items-center space-x-2 px-3 py-2 font-body text-sm text-petal-ink-soft hover:bg-petal-cream-2 rounded-md transition-colors"


### PR DESCRIPTION
## Summary
Refactored the navigation structure by moving the "Coin Shop" and "Settings" features from the main navigation sidebar to the header component, improving UI organization and accessibility.

## Key Changes
- **Header Component Updates**
  - Added `Settings` icon import from lucide-react
  - Added `onShowCoinShop` and `onShowSettings` callback props to HeaderProps interface
  - Converted coin balance display from a static div to an interactive button that opens the coin shop
  - Added hover state styling to the coin balance button for better UX
  - Added "Settings" menu item to the user dropdown menu with appropriate icon and styling

- **App Component Updates**
  - Removed `ShoppingBag` icon import (no longer needed in main nav)
  - Removed "金幣商店" (Coin Shop) and "設定" (Settings) items from the main navigation sidebar
  - Renamed "邀請紀錄" to "訊息紀錄" (Invitation Record → Message Record) for clarity
  - Connected header callbacks to trigger coin shop and settings views via `setCurrentView`

## Implementation Details
- The coin balance now functions as a clickable button with visual feedback (border color change on hover)
- Settings option is now accessible from the user menu dropdown in the header
- Both features maintain their original functionality, just accessed through different UI entry points
- Maintains consistent styling with existing header components using the petal design system

https://claude.ai/code/session_01QTaFP9gWqx6f8YqDZL4Qxh