### PR TITLE
fix(intimacy+coins): kill users.coins schema-drift; surface backend error messages

### DIFF
--- a/routes/coins.js
+++ b/routes/coins.js
@@ -209,19 +209,25 @@ router.post('/spend', [
     const userId = req.user.id;
     const { amount, reason, transaction_type } = req.body;
 
-    // Check if user has enough coins
-    const balanceResult = await db.query(
-      'SELECT coins FROM users WHERE id = $1',
+    const coupleResult = await db.query(
+      'SELECT id FROM couples WHERE user1_id = $1 OR user2_id = $1',
       [userId]
     );
 
-    if (balanceResult.rows.length === 0) {
+    if (coupleResult.rows.length === 0) {
       return res.status(404).json({
         success: false,
-        message: '用戶不存在'
+        message: '您還沒有情侶關係'
       });
     }
 
+    const coupleId = coupleResult.rows[0].id;
+
+    const balanceResult = await db.query(`
+      SELECT COALESCE(SUM(CASE WHEN transaction_type = 'earn' THEN amount ELSE -amount END), 0) as balance
+      FROM coin_transactions
+      WHERE couple_id = $1
+    `, [coupleId]);
     const currentBalance = parseInt(balanceResult.rows[0].balance) || 0;
 
     if (currentBalance < amount) {
@@ -233,14 +239,12 @@ router.post('/spend', [
       });
     }
 
-    // Record spend transaction
     const transactionId = uuidv4();
     await db.query(`
       INSERT INTO coin_transactions (id, couple_id, amount, transaction_type, spent_on, description, transaction_date)
       VALUES ($1, $2, $3, 'spend', $4, $5, NOW())
-    `, [transactionId, coupleId, amount, spent_on, reason]);
+    `, [transactionId, coupleId, amount, transaction_type, reason]);
 
-    // Get updated balance
     const updatedBalanceResult = await db.query(`
       SELECT COALESCE(SUM(CASE WHEN transaction_type = 'earn' THEN amount ELSE -amount END), 0) as balance
       FROM coin_transactions

--- a/routes/intimacy-requests.js
+++ b/routes/intimacy-requests.js
@@ -452,33 +452,30 @@ router.put('/:id/respond', [
       [response, response_message || null, now, requestId]
     );
 
-    // If accepted, award coins to both users. Wrapped in try/catch so a
-    // failure here (e.g. schema drift on users.coins or coin_transactions)
-    // doesn't roll back the user's accept action — the response itself
-    // is already persisted above.
+    // If accepted, award coins to the couple's shared balance. Wrapped in
+    // try/catch so an unexpected failure here doesn't roll back the user's
+    // accept — the response itself is already persisted above. The earlier
+    // version of this block wrote to `users.coins` (no such column in prod)
+    // and inserted `user_id` + `transaction_type='bonus'` rows that violate
+    // the coin_transactions schema (couple_id, transaction_type IN
+    // ('earn','spend')). Both were silently failing for every accept.
     if (response === 'accepted') {
-      const coinAmount = 5; // 5 coins for accepted intimacy request
+      const coinAmount = 10;
       try {
-        await db.transaction(async (client) => {
-          await client.query(
-            'UPDATE users SET coins = COALESCE(coins, 0) + $1 WHERE id = $2',
-            [coinAmount, request.sender_id]
-          );
-          await client.query(
-            'UPDATE users SET coins = COALESCE(coins, 0) + $1 WHERE id = $2',
-            [coinAmount, userId]
-          );
-          const transactionId1 = uuidv4();
-          const transactionId2 = uuidv4();
-          await client.query(`
-            INSERT INTO coin_transactions (id, user_id, amount, transaction_type, description, created_at)
-            VALUES ($1, $2, $3, 'bonus', '親密請求被接受獎勵', $4)
-          `, [transactionId1, request.sender_id, coinAmount, now]);
-          await client.query(`
-            INSERT INTO coin_transactions (id, user_id, amount, transaction_type, description, created_at)
-            VALUES ($1, $2, $3, 'bonus', '接受親密請求獎勵', $4)
-          `, [transactionId2, userId, coinAmount, now]);
-        });
+        const coupleResult = await db.query(
+          `SELECT id FROM couples
+           WHERE (user1_id = $1 AND user2_id = $2)
+              OR (user1_id = $2 AND user2_id = $1)`,
+          [request.sender_id, userId]
+        );
+        if (coupleResult.rows.length > 0) {
+          await db.query(`
+            INSERT INTO coin_transactions (id, couple_id, amount, transaction_type, earned_from, description, transaction_date)
+            VALUES ($1, $2, $3, 'earn', 'intimacy_accept', '親密邀請被接受獎勵', $4)
+          `, [uuidv4(), coupleResult.rows[0].id, coinAmount, now]);
+        } else {
+          logWarn('Skipped intimacy accept coins — couple not found', { requestId });
+        }
       } catch (coinError) {
         logWarn('Failed to award intimacy accept coins', { err: coinError.message, code: coinError.code, requestId });
       }

--- a/routes/intimacy-requests.js
+++ b/routes/intimacy-requests.js
@@ -432,7 +432,7 @@ router.put('/:id/respond', [
     if (requestResult.rows.length === 0) {
       return res.status(404).json({
         success: false,
-        message: '找不到指定的請求或您沒有權限回應'
+        message: '這個邀請已被撤回或無法回應，請重新整理頁面'
       });
     }
 
@@ -452,37 +452,36 @@ router.put('/:id/respond', [
       [response, response_message || null, now, requestId]
     );
 
-    // If accepted, award coins to both users
+    // If accepted, award coins to both users. Wrapped in try/catch so a
+    // failure here (e.g. schema drift on users.coins or coin_transactions)
+    // doesn't roll back the user's accept action — the response itself
+    // is already persisted above.
     if (response === 'accepted') {
       const coinAmount = 5; // 5 coins for accepted intimacy request
-      
-      await db.transaction(async (client) => {
-        // Award coins to requester
-        await client.query(
-          'UPDATE users SET coins = COALESCE(coins, 0) + $1 WHERE id = $2',
-          [coinAmount, request.sender_id]
-        );
-        
-        // Award coins to recipient
-        await client.query(
-          'UPDATE users SET coins = COALESCE(coins, 0) + $1 WHERE id = $2',
-          [coinAmount, userId]
-        );
-        
-        // Record transactions
-        const transactionId1 = uuidv4();
-        const transactionId2 = uuidv4();
-        
-        await client.query(`
-          INSERT INTO coin_transactions (id, user_id, amount, transaction_type, description, created_at)
-          VALUES ($1, $2, $3, 'bonus', '親密請求被接受獎勵', $4)
-        `, [transactionId1, request.sender_id, coinAmount, now]);
-        
-        await client.query(`
-          INSERT INTO coin_transactions (id, user_id, amount, transaction_type, description, created_at)
-          VALUES ($1, $2, $3, 'bonus', '接受親密請求獎勵', $4)
-        `, [transactionId2, userId, coinAmount, now]);
-      });
+      try {
+        await db.transaction(async (client) => {
+          await client.query(
+            'UPDATE users SET coins = COALESCE(coins, 0) + $1 WHERE id = $2',
+            [coinAmount, request.sender_id]
+          );
+          await client.query(
+            'UPDATE users SET coins = COALESCE(coins, 0) + $1 WHERE id = $2',
+            [coinAmount, userId]
+          );
+          const transactionId1 = uuidv4();
+          const transactionId2 = uuidv4();
+          await client.query(`
+            INSERT INTO coin_transactions (id, user_id, amount, transaction_type, description, created_at)
+            VALUES ($1, $2, $3, 'bonus', '親密請求被接受獎勵', $4)
+          `, [transactionId1, request.sender_id, coinAmount, now]);
+          await client.query(`
+            INSERT INTO coin_transactions (id, user_id, amount, transaction_type, description, created_at)
+            VALUES ($1, $2, $3, 'bonus', '接受親密請求獎勵', $4)
+          `, [transactionId2, userId, coinAmount, now]);
+        });
+      } catch (coinError) {
+        logWarn('Failed to award intimacy accept coins', { err: coinError.message, code: coinError.code, requestId });
+      }
     }
 
     // Create notification for the original requester about the response

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -524,7 +524,11 @@ apiClient.interceptors.response.use(
         forbiddenError.data = data;
         throw forbiddenError;
       } else if (status === 404) {
-        const notFoundError = new Error('請求的資源不存在') as Error & { error_code?: string; status?: number; data?: unknown };
+        // Prefer the backend's specific message (e.g. "這個邀請已被撤回…")
+        // so the user knows what to do, falling back to a generic string
+        // only when the body has none.
+        const backendMessage = data?.message || data?.error?.message;
+        const notFoundError = new Error(backendMessage || '請求的資源不存在') as Error & { error_code?: string; status?: number; data?: unknown };
         notFoundError.error_code = errorCode;
         notFoundError.status = status;
         notFoundError.data = data;
@@ -537,7 +541,11 @@ apiClient.interceptors.response.use(
         validationError.data = data;
         throw validationError;
       } else if (status >= 500) {
-        const serverError = new Error('服務器內部錯誤，請稍後再試') as Error & { error_code?: string; status?: number; data?: unknown };
+        // Same as 404: surface the backend's specific message when it has
+        // one (e.g. "回應親密請求失敗") so the user sees what feature failed
+        // instead of a featureless "服務器內部錯誤".
+        const backendMessage = data?.message || data?.error?.message;
+        const serverError = new Error(backendMessage || '服務器內部錯誤，請稍後再試') as Error & { error_code?: string; status?: number; data?: unknown };
         serverError.error_code = errorCode;
         serverError.status = status;
         serverError.data = data;


### PR DESCRIPTION
## Summary

Two commits, one root cause — the schema-drift class around `users.coins`.

**Commit 1 — `fix(intimacy)`:** the `/intimacy-requests/:id/respond` endpoint was 500ing in prod because the coin-award block ran `UPDATE users SET coins = ...` against a column that doesn't exist (only ever defined in `database/migrations_backup/001_create_base_schema.sql`, never applied). Confirmed via GCP logs from `twogether-couples-app` 2026-05-30 01:52 UTC: `column "coins" does not exist`. Reported by 小湘 (yang23567@gmail.com) — 服務器內部錯誤 on tapping 接受邀請. Also fixed the UX: the api.ts interceptor was replacing every backend 404/5xx `message` with hardcoded generic strings; now it prefers `data.message` so users see what actually failed. Reworded the respond endpoint's 404 to `這個邀請已被撤回或無法回應，請重新整理頁面` since the receiver always has permission for their own invitations.

**Commit 2 — `fix(coins)`:** same schema-drift class, cleaned up everywhere it lived.
- `routes/coins.js` POST `/spend`: replaced `SELECT coins FROM users` with the same couple-lookup + `coin_transactions` SUM pattern that `/balance`, `/add`, and `/transaction` already use. Also fixed the endpoint's other broken bits — it referenced undefined `coupleId`/`spent_on` locals and wrote the request's `transaction_type` (`'purchase'|'unlock'|'gift'|'other'`) into a column constrained to `'earn'|'spend'`. Now writes `'spend'` to `transaction_type` and stores the category in `spent_on`.
- `routes/intimacy-requests.js` accept-coins block: dropped the dead `UPDATE users SET coins` lines and the broken INSERT (`user_id` not in schema, `transaction_type='bonus'` violates the CHECK, `created_at` should be `transaction_date`). Now does one couple lookup and inserts a single 10-coin `'earn'` row with `earned_from='intimacy_accept'` into the couple's shared balance. Try/catch + `logWarn` stays so coin-write failures still never break the user's accept.

## Test plan

- [x] `npm run test:e2e` — all 17 tests pass (both commits)
- [x] `npx tsc --noEmit` clean
- [ ] Post-deploy: receiver accepts a pending intimacy invitation → no 500, response persists, sender's 邀請被接受 notification fires, +10 coins on the couple's balance
- [ ] Post-deploy: spend coins endpoint actually works (was broken before, not just on `users.coins` but on multiple undefined locals)
- [ ] Post-deploy: if sender deletes the message before receiver responds, receiver sees `這個邀請已被撤回或無法回應` instead of `服務器內部錯誤`

🤖 Generated with [Claude Code](https://claude.com/claude-code)