### PR TITLE
feat(intimacy): tabbed history redesign + couple timezone setting

### DIFF
--- a/database/migrations/035_user_couple_timezone.sql
+++ b/database/migrations/035_user_couple_timezone.sql
@@ -1,0 +1,6 @@
+-- Migration: Add timezone columns for per-user setting and couple-level primary timezone.
+-- users.timezone — viewer's own IANA tz (e.g. 'Asia/Taipei')
+-- couples.primary_timezone — IANA tz used to interpret/display shared timestamps for both partners
+
+ALTER TABLE users   ADD COLUMN timezone         VARCHAR(64);
+ALTER TABLE couples ADD COLUMN primary_timezone VARCHAR(64);

--- a/database/migrations/036_normalize_intimacy_declined.sql
+++ b/database/migrations/036_normalize_intimacy_declined.sql
@@ -1,0 +1,7 @@
+-- Migration: normalize legacy intimacy_requests.status='declined' to 'rejected'.
+-- The schema (migration 009) documents 'rejected' as the canonical reject value, and
+-- the stats query already filters on status='rejected'. The respond route used to
+-- write 'declined' verbatim, which made those rows invisible to stats and rendered
+-- as the default ("待回應") in the new tabbed history UI.
+
+UPDATE intimacy_requests SET status = 'rejected' WHERE status = 'declined';

--- a/lib/timezone-options.js
+++ b/lib/timezone-options.js
@@ -1,0 +1,22 @@
+// Curated IANA timezone list shared by:
+//   - frontend Settings dropdown
+//   - backend validation for PUT /auth/user/timezone and PUT /couples/primary-timezone
+// Keep in sync with src/utils/timezone-options.ts.
+
+const TIMEZONE_OPTIONS = [
+  { value: 'Asia/Taipei',         label: '台北 (GMT+8)',     short: '台北' },
+  { value: 'Asia/Hong_Kong',      label: '香港 (GMT+8)',     short: '香港' },
+  { value: 'Asia/Shanghai',       label: '中國 (GMT+8)',     short: '上海' },
+  { value: 'Asia/Tokyo',          label: '東京 (GMT+9)',     short: '東京' },
+  { value: 'Asia/Seoul',          label: '首爾 (GMT+9)',     short: '首爾' },
+  { value: 'Asia/Singapore',      label: '新加坡 (GMT+8)',   short: '新加坡' },
+  { value: 'America/Los_Angeles', label: '美西 (PT)',        short: '美西' },
+  { value: 'America/New_York',    label: '美東 (ET)',        short: '美東' },
+  { value: 'Europe/London',       label: '倫敦 (GMT/BST)',   short: '倫敦' },
+  { value: 'Europe/Paris',        label: '歐陸 (CET)',       short: '歐陸' },
+  { value: 'Australia/Sydney',    label: '雪梨 (AET)',       short: '雪梨' },
+];
+
+const TIMEZONE_VALUES = TIMEZONE_OPTIONS.map((o) => o.value);
+
+module.exports = { TIMEZONE_OPTIONS, TIMEZONE_VALUES };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,6 +5,7 @@ const { v4: uuidv4 } = require('uuid');
 const db = require('../database/db');
 const { generateToken, authenticateToken } = require('../middleware/auth');
 const { logInfo, logError } = require('../lib/logger');
+const { TIMEZONE_VALUES } = require('../lib/timezone-options');
 
 const router = express.Router();
 
@@ -114,7 +115,7 @@ router.post('/login', [
 
     // Find user
     const userResult = await db.query(
-      'SELECT id, nickname, email, gender, birth_date, password_hash, created_at FROM users WHERE email = $1',
+      'SELECT id, nickname, email, gender, birth_date, timezone, password_hash, created_at FROM users WHERE email = $1',
       [email]
     );
 
@@ -158,6 +159,7 @@ router.post('/login', [
         email: user.email,
         gender: user.gender,
         birth_date: user.birth_date,
+        timezone: user.timezone,
         created_at: user.created_at
       }
     });
@@ -177,10 +179,11 @@ router.get('/me', authenticateToken, async (req, res) => {
     // Get user with couple information
     const userResult = await db.query(`
       SELECT
-        u.id, u.nickname, u.email, u.gender, u.birth_date, u.email_notifications_enabled,
+        u.id, u.nickname, u.email, u.gender, u.birth_date, u.timezone,
+        u.email_notifications_enabled,
         u.cycle_tracking_enabled,
         u.created_at, u.last_login,
-        c.id as couple_id, c.couple_name, c.anniversary_date,
+        c.id as couple_id, c.couple_name, c.anniversary_date, c.primary_timezone,
         c.user1_id, c.user2_id
       FROM users u
       LEFT JOIN couples c ON (c.user1_id = u.id OR c.user2_id = u.id)
@@ -202,7 +205,7 @@ router.get('/me', authenticateToken, async (req, res) => {
       const partnerId = userData.user1_id === req.user.id ? userData.user2_id : userData.user1_id;
       if (partnerId) {
         const partnerResult = await db.query(
-          'SELECT id, nickname, email FROM users WHERE id = $1',
+          'SELECT id, nickname, email, timezone FROM users WHERE id = $1',
           [partnerId]
         );
         if (partnerResult.rows.length > 0) {
@@ -219,6 +222,7 @@ router.get('/me', authenticateToken, async (req, res) => {
         email: userData.email,
         gender: userData.gender,
         birth_date: userData.birth_date,
+        timezone: userData.timezone,
         email_notifications_enabled: userData.email_notifications_enabled !== false,
         cycle_tracking_enabled: userData.cycle_tracking_enabled === true,
         created_at: userData.created_at,
@@ -227,6 +231,7 @@ router.get('/me', authenticateToken, async (req, res) => {
           id: userData.couple_id,
           couple_name: userData.couple_name,
           anniversary_date: userData.anniversary_date,
+          primary_timezone: userData.primary_timezone,
           partner: partner
         } : null
       }
@@ -407,6 +412,48 @@ router.put('/user/birth-date', authenticateToken, [
     res.status(500).json({
       success: false,
       message: '更新生日失敗'
+    });
+  }
+});
+
+// Update user timezone (IANA string from the curated allow-list).
+router.put('/user/timezone', authenticateToken, [
+  body('timezone')
+    .custom((value) => {
+      if (value === null) return true;
+      if (typeof value !== 'string') throw new Error('timezone 必須為字串或 null');
+      if (!TIMEZONE_VALUES.includes(value)) throw new Error('timezone 不在允許清單中');
+      return true;
+    })
+], async (req, res) => {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        success: false,
+        message: '驗證失敗',
+        errors: errors.array()
+      });
+    }
+
+    const userId = req.user.id;
+    const timezone = req.body.timezone === null ? null : req.body.timezone;
+
+    await db.query(
+      `UPDATE users SET timezone = $1 WHERE id = $2`,
+      [timezone, userId]
+    );
+
+    res.json({
+      success: true,
+      message: '時區已更新',
+      timezone: timezone
+    });
+  } catch (error) {
+    logError('Update user timezone failed', { err: error.message, stack: error.stack });
+    res.status(500).json({
+      success: false,
+      message: '更新時區失敗'
     });
   }
 });

--- a/routes/couples.js
+++ b/routes/couples.js
@@ -5,6 +5,7 @@ const db = require('../database/db');
 const { authenticateToken } = require('../middleware/auth');
 const pairingService = require('../services/pairingService');
 const { logInfo, logWarn, logError } = require('../lib/logger');
+const { TIMEZONE_VALUES } = require('../lib/timezone-options');
 
 const router = express.Router();
 
@@ -207,8 +208,9 @@ router.get('/', async (req, res) => {
       SELECT
         c.id, c.couple_name, c.anniversary_date, c.created_at, c.pending_conflicts,
         c.first_meet_date, c.first_date, c.first_kiss_date, c.first_kiss_place, c.first_intimacy_date, c.first_intimacy_place,
-        u1.id as user1_id, u1.nickname as user1_nickname,
-        u2.id as user2_id, u2.nickname as user2_nickname
+        c.primary_timezone,
+        u1.id as user1_id, u1.nickname as user1_nickname, u1.timezone as user1_timezone,
+        u2.id as user2_id, u2.nickname as user2_nickname, u2.timezone as user2_timezone
       FROM couples c
       JOIN users u1 ON c.user1_id = u1.id
       LEFT JOIN users u2 ON c.user2_id = u2.id
@@ -380,6 +382,67 @@ router.put('/journey', [
     res.status(500).json({
       success: false,
       message: '更新情侶旅程失敗'
+    });
+  }
+});
+
+// Update couple's primary timezone (IANA string from the curated allow-list).
+// Used to capture/display all shared timestamps (scheduled intimacy invitations,
+// events, wall posts, achievements, etc.) so both partners see the same wall-clock.
+router.put('/primary-timezone', [
+  body('primary_timezone')
+    .custom((value) => {
+      if (value === null) return true;
+      if (typeof value !== 'string') throw new Error('primary_timezone 必須為字串或 null');
+      if (!TIMEZONE_VALUES.includes(value)) throw new Error('primary_timezone 不在允許清單中');
+      return true;
+    })
+], async (req, res) => {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        success: false,
+        message: '驗證失敗',
+        errors: errors.array()
+      });
+    }
+
+    const userId = req.user.id;
+    const primaryTimezone = req.body.primary_timezone === null ? null : req.body.primary_timezone;
+
+    // Find user's couple (must already exist; this setting is meaningless without a partner).
+    const coupleResult = await db.query(
+      'SELECT id FROM couples WHERE user1_id = $1 OR user2_id = $1',
+      [userId]
+    );
+
+    if (coupleResult.rows.length === 0) {
+      return res.status(404).json({
+        success: false,
+        message: '您還沒有情侶關係'
+      });
+    }
+
+    const coupleId = coupleResult.rows[0].id;
+
+    await db.query(
+      `UPDATE couples SET primary_timezone = $1 WHERE id = $2`,
+      [primaryTimezone, coupleId]
+    );
+
+    logInfo('Couple primary timezone updated', { coupleId, primaryTimezone });
+
+    res.json({
+      success: true,
+      message: '共用時區已更新',
+      primary_timezone: primaryTimezone
+    });
+  } catch (error) {
+    logError('Update couple primary timezone failed', { err: error.message, stack: error.stack });
+    res.status(500).json({
+      success: false,
+      message: '更新共用時區失敗'
     });
   }
 });

--- a/routes/intimacy-requests.js
+++ b/routes/intimacy-requests.js
@@ -94,7 +94,15 @@ router.post('/', [
     .withMessage('訊息不能超過1000個字符'),
   body('request_type')
     .isIn(['general', 'romantic', 'playful', 'surprise', 'compliment', 'intimate', 'reconciliation'])
-    .withMessage('請求類型無效')
+    .withMessage('請求類型無效'),
+  body('scheduled_time')
+    .optional({ nullable: true })
+    .isISO8601()
+    .withMessage('scheduled_time 必須為 ISO8601 字串'),
+  body('roleplay_category')
+    .optional({ nullable: true })
+    .isLength({ max: 100 })
+    .withMessage('roleplay_category 過長')
 ], async (req, res) => {
   try {
     const errors = validationResult(req);
@@ -108,9 +116,9 @@ router.post('/', [
     }
 
     const userId = req.user.id;
-    const { message, request_type } = req.body;
-    
-    logInfo('Creating intimacy request', { userId, request_type, hasMessage: !!message });
+    const { message, request_type, scheduled_time, roleplay_category } = req.body;
+
+    logInfo('Creating intimacy request', { userId, request_type, hasMessage: !!message, hasSchedule: !!scheduled_time });
 
     // Find user's couple and partner
     const coupleResult = await db.query(`
@@ -139,11 +147,11 @@ router.post('/', [
     const result = await db.query(`
       INSERT INTO intimacy_requests (
         id, couple_id, sender_id, receiver_id, message_content, request_type,
-        status, created_at
+        roleplay_category, scheduled_time, status, created_at
       )
-      VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7)
-      RETURNING id, message_content, request_type, status, created_at
-    `, [requestId, coupleId, userId, partnerId, message || null, request_type, now]);
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', $9)
+      RETURNING id, message_content, request_type, roleplay_category, scheduled_time, status, created_at
+    `, [requestId, coupleId, userId, partnerId, message || null, request_type, roleplay_category || null, scheduled_time || null, now]);
 
     const request = result.rows[0];
 
@@ -349,8 +357,11 @@ router.get('/', async (req, res) => {
     params.push(parseInt(limit), offset);
     
     const result = await db.query(`
-      SELECT 
-        ir.id, ir.message_content, ir.request_type, ir.status, ir.created_at, ir.responded_at,
+      SELECT
+        ir.id, ir.message_content, ir.request_type, ir.roleplay_category,
+        ir.scheduled_time, ir.status, ir.created_at, ir.responded_at, ir.expires_at,
+        ir.response_message, ir.alternative_type, ir.alternative_content,
+        ir.alternative_scheduled_time,
         sender.id as sender_id, sender.nickname as sender_nickname,
         receiver.id as receiver_id, receiver.nickname as receiver_nickname,
         CASE WHEN ir.sender_id = $1 THEN 'sent' ELSE 'received' END as direction
@@ -366,10 +377,17 @@ router.get('/', async (req, res) => {
       id: row.id,
       message_content: row.message_content,
       request_type: row.request_type,
+      roleplay_category: row.roleplay_category,
+      scheduled_time: row.scheduled_time,
       status: row.status,
       direction: row.direction,
       created_at: row.created_at,
       responded_at: row.responded_at,
+      expires_at: row.expires_at,
+      response_message: row.response_message,
+      alternative_type: row.alternative_type,
+      alternative_content: row.alternative_content,
+      alternative_scheduled_time: row.alternative_scheduled_time,
       sender_nickname: row.sender_nickname,
       receiver_nickname: row.receiver_nickname,
       requester: {
@@ -402,12 +420,22 @@ router.get('/', async (req, res) => {
 // Respond to intimacy request
 router.put('/:id/respond', [
   body('response')
-    .isIn(['accepted', 'declined'])
-    .withMessage('回應必須是 accepted 或 declined'),
+    .isIn(['accepted', 'declined', 'rejected'])
+    .withMessage('回應必須是 accepted、declined 或 rejected'),
   body('response_message')
-    .optional()
+    .optional({ nullable: true })
     .isLength({ max: 500 })
-    .withMessage('回應訊息不能超過500個字符')
+    .withMessage('回應訊息不能超過500個字符'),
+  body('alternative_type')
+    .optional({ nullable: true })
+    .isLength({ max: 50 }),
+  body('alternative_content')
+    .optional({ nullable: true })
+    .isLength({ max: 500 }),
+  body('alternative_scheduled_time')
+    .optional({ nullable: true })
+    .isISO8601()
+    .withMessage('alternative_scheduled_time 必須為 ISO8601 字串')
 ], async (req, res) => {
   try {
     const errors = validationResult(req);
@@ -421,7 +449,13 @@ router.put('/:id/respond', [
 
     const userId = req.user.id;
     const requestId = req.params.id;
-    const { response, response_message } = req.body;
+    const {
+      response,
+      response_message,
+      alternative_type,
+      alternative_content,
+      alternative_scheduled_time,
+    } = req.body;
 
     // Check if user is the recipient of this request
     const requestResult = await db.query(
@@ -445,11 +479,31 @@ router.put('/:id/respond', [
       });
     }
 
+    // Normalize: schema canonical is 'rejected' (per migration 009); 'declined' came
+    // in from older clients. Keep the API tolerant but store the canonical value so
+    // the stats query (which counts 'rejected') stays in sync.
+    const normalizedStatus = response === 'accepted' ? 'accepted' : 'rejected';
+
     // Update request status
     const now = new Date().toISOString();
     await db.query(
-      'UPDATE intimacy_requests SET status = $1, response_message = $2, responded_at = $3 WHERE id = $4',
-      [response, response_message || null, now, requestId]
+      `UPDATE intimacy_requests
+       SET status = $1,
+           response_message = $2,
+           responded_at = $3,
+           alternative_type = $4,
+           alternative_content = $5,
+           alternative_scheduled_time = $6
+       WHERE id = $7`,
+      [
+        normalizedStatus,
+        response_message || null,
+        now,
+        alternative_type || null,
+        alternative_content || null,
+        alternative_scheduled_time || null,
+        requestId,
+      ]
     );
 
     // If accepted, award coins to the couple's shared balance. Wrapped in

--- a/scripts/test-datetime.cjs
+++ b/scripts/test-datetime.cjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Standalone round-trip test for the timezone math used in src/utils/datetime.ts.
+// Mirrors localInputToIsoInTz / isoToLocalInputInTz exactly so reviewers can verify
+// the algorithm without a JS test runner. Run with: node scripts/test-datetime.cjs
+
+function localInputToIsoInTz(localValue, tz) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(localValue);
+  if (!m) return '';
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const d = Number(m[3]);
+  const h = Number(m[4]);
+  const mi = Number(m[5]);
+  const s = Number(m[6] || 0);
+  const candidateUtc = Date.UTC(y, mo - 1, d, h, mi, s);
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  });
+  const parts = dtf.formatToParts(new Date(candidateUtc));
+  const get = (t) => Number(parts.find((p) => p.type === t).value);
+  const tzY = get('year');
+  const tzMo = get('month');
+  const tzD = get('day');
+  let tzH = get('hour');
+  const tzMi = get('minute');
+  const tzS = get('second');
+  if (tzH === 24) tzH = 0;
+  const tzWallAsUtc = Date.UTC(tzY, tzMo - 1, tzD, tzH, tzMi, tzS);
+  const offsetMs = tzWallAsUtc - candidateUtc;
+  return new Date(candidateUtc - offsetMs).toISOString();
+}
+
+function isoToLocalInputInTz(iso, tz) {
+  const date = new Date(iso);
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+  const parts = dtf.formatToParts(date);
+  const get = (t) => parts.find((p) => p.type === t).value;
+  let h = get('hour');
+  if (h === '24') h = '00';
+  return `${get('year')}-${get('month')}-${get('day')}T${h}:${get('minute')}`;
+}
+
+let pass = 0, fail = 0;
+
+function assertEq(actual, expected, label) {
+  if (actual === expected) {
+    pass++;
+    console.log(`  ✓ ${label}`);
+  } else {
+    fail++;
+    console.log(`  ✗ ${label}\n      expected: ${expected}\n      actual:   ${actual}`);
+  }
+}
+
+function roundTrip(localValue, tz) {
+  const iso = localInputToIsoInTz(localValue, tz);
+  const back = isoToLocalInputInTz(iso, tz);
+  return { iso, back };
+}
+
+console.log('Asia/Taipei (no DST, fixed +08:00)');
+{
+  const { iso, back } = roundTrip('2026-05-30T20:00', 'Asia/Taipei');
+  assertEq(iso, '2026-05-30T12:00:00.000Z', 'iso matches +08:00 offset');
+  assertEq(back, '2026-05-30T20:00', 'wall-clock round-trips');
+}
+
+console.log('America/Los_Angeles (PDT, summer)');
+{
+  const { iso, back } = roundTrip('2026-06-15T18:00', 'America/Los_Angeles');
+  assertEq(iso, '2026-06-16T01:00:00.000Z', 'iso matches -07:00 PDT offset');
+  assertEq(back, '2026-06-15T18:00', 'wall-clock round-trips');
+}
+
+console.log('America/Los_Angeles (PST, winter)');
+{
+  const { iso, back } = roundTrip('2026-01-15T18:00', 'America/Los_Angeles');
+  assertEq(iso, '2026-01-16T02:00:00.000Z', 'iso matches -08:00 PST offset');
+  assertEq(back, '2026-01-15T18:00', 'wall-clock round-trips');
+}
+
+console.log('Europe/London (BST, summer)');
+{
+  const { iso, back } = roundTrip('2026-06-15T12:00', 'Europe/London');
+  assertEq(iso, '2026-06-15T11:00:00.000Z', 'iso matches +01:00 BST offset');
+  assertEq(back, '2026-06-15T12:00', 'wall-clock round-trips');
+}
+
+console.log('Europe/London (GMT, winter)');
+{
+  const { iso, back } = roundTrip('2026-01-15T12:00', 'Europe/London');
+  assertEq(iso, '2026-01-15T12:00:00.000Z', 'iso matches +00:00 GMT offset');
+  assertEq(back, '2026-01-15T12:00', 'wall-clock round-trips');
+}
+
+console.log('Cross-timezone scenario: Taipei sender, LA viewer');
+{
+  // Sender in Taipei picks "2026-05-30 20:00" (Taipei wall-clock)
+  const iso = localInputToIsoInTz('2026-05-30T20:00', 'Asia/Taipei');
+  // Viewer in LA prefilling: same ISO → LA wall-clock should be 5:00 AM same day (PDT)
+  const laWallClock = isoToLocalInputInTz(iso, 'America/Los_Angeles');
+  assertEq(laWallClock, '2026-05-30T05:00', 'LA viewer sees 5:00 AM same day');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import PairingInvitationHandler from './components/PairingInvitationHandler';
 import { apiService, getTokenExpiry, clearAuthStorage } from './services/api';
 import type { CycleRecord } from './services/api';
 import { periodDateSet, fertileDateSet, predictedPeriodDateSet } from './utils/cycle';
+import { getPrimaryTimezone, formatMonthYear } from './utils/datetime';
+import { TimezoneProvider } from './contexts/TimezoneContext';
 import { conflictPhraseTiers } from './data/conflictSteps';
 import { useScrollLock } from './hooks/useScrollLock';
 
@@ -127,6 +129,9 @@ interface User {
   birth_date?: string | null;
   email_notifications_enabled?: boolean;
   cycle_tracking_enabled?: boolean;
+  timezone?: string | null;
+  couplePrimaryTimezone?: string | null;
+  partnerTimezone?: string | null;
   partnerId?: string;
   partnerCode?: string;
   partnerNickname?: string;
@@ -598,6 +603,8 @@ const LoveTimeApp = () => {
         email: string;
         nickname: string;
         gender?: 'male' | 'female' | 'other';
+        birth_date?: string | null;
+        timezone?: string | null;
         created_at?: string;
       };
 
@@ -606,6 +613,8 @@ const LoveTimeApp = () => {
         email: userData.email,
         nickname: userData.nickname,
         gender: userData.gender,
+        birth_date: userData.birth_date,
+        timezone: userData.timezone,
         partnerCode: generatePartnerCode(),
         createdAt: userData.created_at || new Date().toISOString()
       };
@@ -1011,10 +1020,19 @@ const LoveTimeApp = () => {
           if (coupleInfo && authUser) {
             const nextPartnerConnected = !!coupleInfo.user2Nickname;
             const nextPartnerNickname = storedNicknames.partner2 || undefined;
+            const nextCouplePrimaryTz = coupleInfo.primaryTimezone ?? null;
+            const nextPartnerTz =
+              coupleInfo.user1Id === authUser.id
+                ? coupleInfo.user2Timezone ?? null
+                : coupleInfo.user2Id === authUser.id
+                  ? coupleInfo.user1Timezone ?? null
+                  : null;
 
             const needsUpdate =
               authUser.partnerId !== coupleInfo.id ||
               authUser.partnerNickname !== nextPartnerNickname ||
+              authUser.couplePrimaryTimezone !== nextCouplePrimaryTz ||
+              authUser.partnerTimezone !== nextPartnerTz ||
               partnerConnected !== nextPartnerConnected;
 
             if (needsUpdate) {
@@ -1024,7 +1042,9 @@ const LoveTimeApp = () => {
                 user: {
                   ...authUser,
                   partnerId: coupleInfo.id,
-                  partnerNickname: nextPartnerNickname // partner2 is always the partner's nickname
+                  partnerNickname: nextPartnerNickname, // partner2 is always the partner's nickname
+                  couplePrimaryTimezone: nextCouplePrimaryTz,
+                  partnerTimezone: nextPartnerTz,
                 }
               };
 
@@ -5544,7 +5564,7 @@ const LoveTimeApp = () => {
     };
 
     const days = getDaysInMonth(currentMonth);
-    const monthYear = currentMonth.toLocaleDateString('zh-TW', { year: 'numeric', month: 'long' });
+    const monthYear = formatMonthYear(currentMonth, primaryTimezone);
 
     return (
       <div className="bg-white rounded-md p-5 border border-petal-rule">
@@ -5598,7 +5618,13 @@ const LoveTimeApp = () => {
     );
   };
 
+  const primaryTimezone = getPrimaryTimezone({
+    couplePrimaryTz: authState.user?.couplePrimaryTimezone,
+    userTz: authState.user?.timezone,
+  });
+
   return (
+    <TimezoneProvider value={primaryTimezone}>
     <div className="min-h-screen bg-petal-cream">
       {/* Header */}
       <Header
@@ -6019,6 +6045,7 @@ const LoveTimeApp = () => {
         </div>
       )}
     </div>
+    </TimezoneProvider>
   );
 };
 

--- a/src/components/AchievementsView.tsx
+++ b/src/components/AchievementsView.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import apiService from '../services/api';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatDate } from '../utils/datetime';
 
 interface IntimateRecord {
   id: number;
@@ -65,6 +67,7 @@ export function AchievementsView() {
   const [error, setError] = useState<string | null>(null);
   // Fetch all records for badge logic
   const [records, setRecords] = useState<IntimateRecord[]>([]);
+  const tz = useTimezone();
   useEffect(() => {
     (async () => {
       try {
@@ -248,7 +251,7 @@ export function AchievementsView() {
                     </div>
                     {achievement.unlocked_at && (
                       <p className="text-xs text-green-600">
-                        解鎖於 {new Date(achievement.unlocked_at).toLocaleDateString('zh-TW')}
+                        解鎖於 {formatDate(achievement.unlocked_at, tz, { year: 'numeric', month: 'numeric', day: 'numeric', withWeekday: false })}
                       </p>
                     )}
                   </div>

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -18,6 +18,8 @@ import apiService, {
 } from '../services/api';
 import ReplyStepBar from './ReplyStepBar';
 import { useScrollLock } from '../hooks/useScrollLock';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatDateTime } from '../utils/datetime';
 
 interface NotificationInput {
   type: 'success' | 'error' | 'info' | 'warning';
@@ -54,15 +56,10 @@ function statusPill(status: EventStatus) {
   }
 }
 
-function formatTime(iso: string) {
+function formatTime(iso: string, tz: string) {
   if (!iso) return '';
   try {
-    return new Date(iso).toLocaleString('zh-TW', {
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+    return formatDateTime(iso, tz);
   } catch {
     return iso;
   }
@@ -77,6 +74,7 @@ export default function EventDetail({ eventId, currentUserId, onBack, showNotifi
   const [resolving, setResolving] = useState(false);
   const [rewriting, setRewriting] = useState(false);
   const [rewritePreview, setRewritePreview] = useState<ReplyRewritePreview | null>(null);
+  const tz = useTimezone();
 
   const insertPhrase = (phrase: string) => {
     setReply((prev) => (prev.trim().length > 0 ? `${prev}\n${phrase}` : phrase));
@@ -215,7 +213,7 @@ export default function EventDetail({ eventId, currentUserId, onBack, showNotifi
           </div>
         </div>
         <p className="text-xs text-petal-muted mb-3">
-          {formatTime(event.createdAt)}・{isAuthor ? '你發起' : '伴侶發起'}
+          {formatTime(event.createdAt, tz)}・{isAuthor ? '你發起' : '伴侶發起'}
         </p>
 
         <p className="text-sm text-petal-ink-soft leading-relaxed mb-3 whitespace-pre-wrap">{event.summary}</p>
@@ -254,7 +252,7 @@ export default function EventDetail({ eventId, currentUserId, onBack, showNotifi
                 >
                   <p className="text-sm text-petal-ink whitespace-pre-wrap">{m.content}</p>
                   <p className="text-[10px] text-petal-muted mt-1 flex items-center gap-1">
-                    <span>{formatTime(m.createdAt)}</span>
+                    <span>{formatTime(m.createdAt, tz)}</span>
                     {mine && m.readAt && <span>・已讀</span>}
                   </p>
                 </div>

--- a/src/components/EventHistoryList.tsx
+++ b/src/components/EventHistoryList.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Tag, CheckCircle2, Clock, Lock, MessageSquareHeart } from 'lucide-react';
 import apiService, { type EventRecord, type EventStatus } from '../services/api';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatDateTime } from '../utils/datetime';
 
 interface EventHistoryListProps {
   onOpenEvent: (id: string) => void;
@@ -37,16 +39,10 @@ function statusPill(status: EventStatus) {
   }
 }
 
-function formatDate(iso: string) {
+function formatDate(iso: string, tz: string) {
   if (!iso) return '';
   try {
-    return new Date(iso).toLocaleString('zh-TW', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+    return formatDateTime(iso, tz, { withYear: true });
   } catch {
     return iso;
   }
@@ -62,6 +58,7 @@ export default function EventHistoryList({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<EventStatus | 'all'>(filterStatus ?? 'all');
+  const tz = useTimezone();
 
   useEffect(() => {
     let cancelled = false;
@@ -151,7 +148,7 @@ export default function EventHistoryList({
           </div>
 
           <p className="text-xs text-petal-muted mb-2">
-            {formatDate(event.createdAt)}
+            {formatDate(event.createdAt, tz)}
             {event.createdBy === currentUserId ? '・你發起' : '・伴侶發起'}
           </p>
 

--- a/src/components/IntimacyRequestActionPanel.tsx
+++ b/src/components/IntimacyRequestActionPanel.tsx
@@ -7,11 +7,27 @@ import type {
   AlternativeIntimacyOption,
   RespondToIntimacyRequestRequest,
 } from '../services/api';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { localInputToIsoInTz, formatDateTime } from '../utils/datetime';
+import { getTimezoneShortLabel } from '../utils/timezone-options';
 
 interface IntimacyRequestActionPanelProps {
   request: IntimacyRequest;
   onResponded: () => void;
 }
+
+const AFFIRMATION_SUGGESTIONS = [
+  '謝謝你想到我 ❤️',
+  '我也很想跟你親近',
+  '很開心你願意主動邀我',
+];
+
+const CLOSING_SUGGESTIONS = [
+  '到時見 💕',
+  '等不及了',
+  '我也想你',
+  '抱抱',
+];
 
 const getCategoryIcon = (category: string) => {
   switch (category) {
@@ -33,23 +49,31 @@ const getCategoryName = (category: string) => {
   }
 };
 
+type Mode = 'choice' | 'accept' | 'alternative';
+
 const IntimacyRequestActionPanel: React.FC<IntimacyRequestActionPanelProps> = ({
   request,
   onResponded,
 }) => {
-  const [showAlternatives, setShowAlternatives] = useState(false);
+  const tz = useTimezone();
+  const [mode, setMode] = useState<Mode>('choice');
+  const [acceptMessage, setAcceptMessage] = useState<string>('接受你的邀請 💕');
+
+  // 4-step alternative flow state
+  const [affirmation, setAffirmation] = useState<string>('');
   const [alternativeOptions, setAlternativeOptions] = useState<AlternativeIntimacyOptionsGrouped | null>(null);
   const [selectedAlternative, setSelectedAlternative] = useState<{
     type: string;
     content: string;
-    scheduledTime?: string;
   } | null>(null);
-  const [acceptMessage, setAcceptMessage] = useState<string>('接受你的邀請 💕');
+  const [altScheduledLocal, setAltScheduledLocal] = useState<string>('');
+  const [closing, setClosing] = useState<string>('');
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (showAlternatives && !alternativeOptions) {
+    if (mode === 'alternative' && !alternativeOptions) {
       apiService
         .getAlternativeIntimacyOptions()
         .then(setAlternativeOptions)
@@ -58,7 +82,7 @@ const IntimacyRequestActionPanel: React.FC<IntimacyRequestActionPanelProps> = ({
           setError('無法載入替代選項');
         });
     }
-  }, [showAlternatives, alternativeOptions]);
+  }, [mode, alternativeOptions]);
 
   const handleAccept = async () => {
     try {
@@ -76,17 +100,23 @@ const IntimacyRequestActionPanel: React.FC<IntimacyRequestActionPanelProps> = ({
     }
   };
 
+  const canSendAlternative =
+    affirmation.trim().length > 0 &&
+    altScheduledLocal.length > 0 &&
+    closing.trim().length > 0;
+
   const handleSendAlternative = async () => {
-    if (!selectedAlternative) return;
+    if (!canSendAlternative) return;
     try {
       setLoading(true);
       setError(null);
+      const responseMessage = `${affirmation.trim()}\n\n${closing.trim()}`;
       const response: RespondToIntimacyRequestRequest = {
         accept: false,
-        responseMessage: '現在不太合適，但我們可以試試這個 💝',
-        alternativeType: selectedAlternative.type,
-        alternativeContent: selectedAlternative.content,
-        alternativeScheduledTime: selectedAlternative.scheduledTime,
+        responseMessage,
+        alternativeType: selectedAlternative?.type,
+        alternativeContent: selectedAlternative?.content,
+        alternativeScheduledTime: localInputToIsoInTz(altScheduledLocal, tz),
       };
       await apiService.respondToIntimacyRequest(request.id, response);
       onResponded();
@@ -105,7 +135,29 @@ const IntimacyRequestActionPanel: React.FC<IntimacyRequestActionPanelProps> = ({
         </div>
       )}
 
-      {!showAlternatives ? (
+      {mode === 'choice' && (
+        <div className="flex flex-wrap gap-3">
+          <button
+            data-testid="intimacy-show-accept-button"
+            onClick={() => setMode('accept')}
+            disabled={loading}
+            className="flex-1 min-w-[8rem] px-4 py-2 bg-pink-500 text-white rounded-lg hover:bg-pink-600 disabled:bg-pink-300 transition-colors flex items-center justify-center gap-2"
+          >
+            <Check className="w-4 h-4" />
+            <span>接受邀請</span>
+          </button>
+          <button
+            data-testid="intimacy-show-alternative-button"
+            onClick={() => setMode('alternative')}
+            disabled={loading}
+            className="flex-1 min-w-[8rem] px-4 py-2 border border-pink-300 text-pink-700 bg-white rounded-lg hover:bg-pink-50 transition-colors"
+          >
+            想改一下方式
+          </button>
+        </div>
+      )}
+
+      {mode === 'accept' && (
         <div className="space-y-3">
           <div>
             <label className="block text-sm text-gray-700 mb-1">給對方的回覆（可自訂）</label>
@@ -117,83 +169,165 @@ const IntimacyRequestActionPanel: React.FC<IntimacyRequestActionPanelProps> = ({
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-pink-200"
             />
           </div>
-          <div className="flex space-x-3">
+          <div className="flex gap-3">
+            <button
+              onClick={() => setMode('choice')}
+              disabled={loading}
+              className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              返回
+            </button>
             <button
               data-testid="intimacy-accept-button"
               onClick={handleAccept}
               disabled={loading}
-              className="px-4 py-2 bg-pink-500 text-white rounded-lg hover:bg-pink-600 disabled:bg-pink-300 transition-colors flex items-center space-x-2"
+              className="px-4 py-2 bg-pink-500 text-white rounded-lg hover:bg-pink-600 disabled:bg-pink-300 transition-colors flex items-center gap-2"
             >
               <Check className="w-4 h-4" />
-              <span>接受邀請</span>
-            </button>
-            <button
-              data-testid="intimacy-alternatives-button"
-              onClick={() => setShowAlternatives(true)}
-              disabled={loading}
-              className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-            >
-              改個時間
+              <span>{loading ? '送出中…' : '送出接受'}</span>
             </button>
           </div>
         </div>
-      ) : (
-        <div>
-          <h4 className="font-semibold text-gray-900 mb-3">選擇替代的親密方式</h4>
+      )}
 
-          {!alternativeOptions ? (
-            <div className="py-4 text-sm text-gray-500">載入中…</div>
-          ) : (
-            <div className="space-y-4">
-              {Object.entries(alternativeOptions).map(([category, options]) => (
-                <div key={category}>
-                  <div className="flex items-center space-x-2 mb-2">
-                    {getCategoryIcon(category)}
-                    <h5 className="font-medium text-gray-900">{getCategoryName(category)}</h5>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                    {(options as AlternativeIntimacyOption[]).map((option) => (
-                      <button
-                        key={option.id}
-                        onClick={() =>
-                          setSelectedAlternative({ type: category, content: option.title })
-                        }
-                        className={`p-3 text-left border rounded-lg transition-colors ${
-                          selectedAlternative?.content === option.title
-                            ? 'border-pink-300 bg-pink-50'
-                            : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
-                        }`}
-                      >
-                        <div className="font-medium text-gray-900 text-sm">{option.title}</div>
-                        <div className="text-xs text-gray-600 mt-1">{option.description}</div>
-                        {option.estimatedDuration && (
-                          <div className="text-xs text-gray-500 mt-1">{option.estimatedDuration}</div>
-                        )}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+      {mode === 'alternative' && (
+        <div className="space-y-5">
+          <p className="text-xs text-pink-700 bg-white border border-pink-200 rounded-md px-3 py-2">
+            想改一下方式時，依下面四個步驟回應，讓對方感受到被在乎：先肯定 → 想試試的方式 → 想改到的時間 → 結尾甜蜜話。
+          </p>
+
+          {/* Step 1 — affirmation */}
+          <section>
+            <h5 className="font-medium text-gray-900 text-sm mb-1">① 先謝謝對方</h5>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {AFFIRMATION_SUGGESTIONS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setAffirmation(s)}
+                  className="text-xs px-2 py-1 rounded-full bg-white border border-pink-200 text-pink-700 hover:bg-pink-100 transition-colors"
+                >
+                  {s}
+                </button>
               ))}
             </div>
-          )}
+            <textarea
+              data-testid="intimacy-affirmation"
+              value={affirmation}
+              onChange={(e) => setAffirmation(e.target.value)}
+              rows={2}
+              placeholder="例如：謝謝你想到我"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-pink-200 text-sm resize-none"
+            />
+          </section>
 
-          <div className="flex justify-end space-x-3 mt-4">
+          {/* Step 2 — alternative activity (optional) */}
+          <section>
+            <h5 className="font-medium text-gray-900 text-sm mb-1">
+              ② 想試試這個方式 <span className="text-xs text-gray-500 font-normal">（選填，可保持原邀請）</span>
+            </h5>
+            {!alternativeOptions ? (
+              <div className="py-3 text-sm text-gray-500">載入中…</div>
+            ) : (
+              <div className="space-y-3 max-h-64 overflow-y-auto pr-1">
+                {Object.entries(alternativeOptions).map(([category, options]) => (
+                  <div key={category}>
+                    <div className="flex items-center gap-2 mb-1.5">
+                      {getCategoryIcon(category)}
+                      <span className="text-sm font-medium text-gray-900">{getCategoryName(category)}</span>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                      {(options as AlternativeIntimacyOption[]).map((option) => (
+                        <button
+                          key={option.id}
+                          type="button"
+                          onClick={() =>
+                            setSelectedAlternative((prev) =>
+                              prev?.content === option.title
+                                ? null
+                                : { type: category, content: option.title }
+                            )
+                          }
+                          className={`p-2.5 text-left border rounded-lg transition-colors ${
+                            selectedAlternative?.content === option.title
+                              ? 'border-pink-400 bg-pink-50 ring-1 ring-pink-300'
+                              : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50 bg-white'
+                          }`}
+                        >
+                          <div className="font-medium text-gray-900 text-sm">{option.title}</div>
+                          <div className="text-xs text-gray-600 mt-0.5">{option.description}</div>
+                          {option.estimatedDuration && (
+                            <div className="text-xs text-gray-500 mt-0.5">{option.estimatedDuration}</div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* Step 3 — required new time */}
+          <section>
+            <h5 className="font-medium text-gray-900 text-sm mb-1">
+              ③ 想改到這個時間 <span className="text-xs text-red-500 font-normal">必填</span>
+            </h5>
+            <input
+              data-testid="intimacy-alt-scheduled-time"
+              type="datetime-local"
+              value={altScheduledLocal}
+              onChange={(e) => setAltScheduledLocal(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-pink-200 text-sm"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              以共用時區（{getTimezoneShortLabel(tz)}）顯示。
+              {altScheduledLocal && (
+                <> 對方會看到：<span className="text-gray-700">{formatDateTime(localInputToIsoInTz(altScheduledLocal, tz), tz, { alwaysShowTz: true })}</span></>
+              )}
+            </p>
+          </section>
+
+          {/* Step 4 — closing */}
+          <section>
+            <h5 className="font-medium text-gray-900 text-sm mb-1">④ 結尾一句甜蜜</h5>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {CLOSING_SUGGESTIONS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setClosing(s)}
+                  className="text-xs px-2 py-1 rounded-full bg-white border border-pink-200 text-pink-700 hover:bg-pink-100 transition-colors"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+            <textarea
+              data-testid="intimacy-closing"
+              value={closing}
+              onChange={(e) => setClosing(e.target.value)}
+              rows={2}
+              placeholder="例如：到時見 💕"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-pink-200 text-sm resize-none"
+            />
+          </section>
+
+          <div className="flex gap-3 justify-end">
             <button
-              onClick={() => {
-                setShowAlternatives(false);
-                setSelectedAlternative(null);
-              }}
+              onClick={() => setMode('choice')}
+              disabled={loading}
               className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
             >
-              取消
+              返回
             </button>
             <button
               data-testid="intimacy-send-alternative-button"
               onClick={handleSendAlternative}
-              disabled={!selectedAlternative || loading}
-              className="px-4 py-2 bg-pink-500 text-white rounded-lg hover:bg-pink-600 disabled:bg-pink-300 transition-colors"
+              disabled={!canSendAlternative || loading}
+              className="px-4 py-2 bg-pink-500 text-white rounded-lg hover:bg-pink-600 disabled:bg-pink-300 disabled:cursor-not-allowed transition-colors"
             >
-              {loading ? '發送中...' : '發送建議'}
+              {loading ? '送出中…' : '送出回應'}
             </button>
           </div>
         </div>

--- a/src/components/IntimacyRequestActionPanel.tsx
+++ b/src/components/IntimacyRequestActionPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Heart, Check, Clock, Smile, Coffee, HandHeart } from 'lucide-react';
+import { Heart, Check, Smile, Coffee, HandHeart } from 'lucide-react';
 import { apiService } from '../services/api';
 import type {
   IntimacyRequest,
@@ -98,19 +98,10 @@ const IntimacyRequestActionPanel: React.FC<IntimacyRequestActionPanelProps> = ({
   };
 
   return (
-    <div className="mt-3 rounded-xl border border-pink-200 bg-pink-50 p-4">
+    <div className="rounded-xl border border-pink-200 bg-pink-50 p-4">
       {error && (
         <div className="mb-3 rounded-md bg-red-50 border border-red-200 p-2 text-sm text-red-600">
           {error}
-        </div>
-      )}
-
-      {request.scheduledTime && (
-        <div className="flex items-center space-x-2 text-sm text-gray-600 mb-3">
-          <Clock className="w-4 h-4" />
-          <span>
-            預約時間：{new Date(request.scheduledTime).toLocaleString('zh-TW')}
-          </span>
         </div>
       )}
 

--- a/src/components/IntimacyRequestDetailModal.tsx
+++ b/src/components/IntimacyRequestDetailModal.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { Calendar, X, MessageSquareHeart, Sparkles } from 'lucide-react';
+import type { IntimacyRequest } from '../services/api';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatDateTime } from '../utils/datetime';
+import { useScrollLock } from '../hooks/useScrollLock';
+import IntimacyRequestActionPanel from './IntimacyRequestActionPanel';
+
+interface IntimacyRequestDetailModalProps {
+  request: IntimacyRequest | null;
+  direction: 'sent' | 'received';
+  onClose: () => void;
+  onResponded: () => void;
+}
+
+const ALTERNATIVE_CATEGORY_LABEL: Record<string, string> = {
+  physical: '肢體親密',
+  emotional: '情感親密',
+  playful: '趣味互動',
+  companionship: '日常陪伴',
+  custom: '自訂',
+};
+
+function statusLabel(status: string): string {
+  if (status === 'accepted') return '已接受';
+  if (status === 'rejected' || status === 'declined') return '已拒絕';
+  if (status === 'expired') return '已過期';
+  return '待回應';
+}
+
+function statusBadgeClass(status: string): string {
+  if (status === 'accepted') return 'bg-green-100 text-green-700';
+  if (status === 'pending') return 'bg-yellow-100 text-yellow-700';
+  if (status === 'rejected' || status === 'declined') return 'bg-red-100 text-red-700';
+  return 'bg-gray-100 text-gray-600';
+}
+
+const IntimacyRequestDetailModal: React.FC<IntimacyRequestDetailModalProps> = ({
+  request,
+  direction,
+  onClose,
+  onResponded,
+}) => {
+  const tz = useTimezone();
+  useScrollLock(!!request);
+
+  if (!request) return null;
+
+  const isPending = request.status === 'pending';
+  const isRejected = request.status === 'rejected' || request.status === 'declined';
+  const responseTitle = direction === 'sent' ? '對方的回應' : '你的回應';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-t-2xl sm:rounded-2xl w-full sm:max-w-lg max-h-[92vh] overflow-hidden flex flex-col shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-petal-rule">
+          <div className="flex items-center gap-2">
+            <h3 className="font-display text-lg font-medium text-petal-ink">
+              {direction === 'sent' ? '我發送的邀請' : '我收到的邀請'}
+            </h3>
+            <span
+              className={`text-xs whitespace-nowrap inline-flex items-center justify-center text-center px-2 py-0.5 rounded-full ${statusBadgeClass(request.status)}`}
+            >
+              {statusLabel(request.status)}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="關閉"
+            className="p-1.5 rounded-full hover:bg-petal-cream-2 text-petal-ink"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto px-5 py-4 space-y-5">
+          {/* Original invitation */}
+          <section>
+            <div className="text-xs uppercase tracking-[0.12em] text-petal-muted mb-1.5">原邀請</div>
+            {request.scheduledTime && (
+              <div className="inline-flex items-center gap-1.5 text-sm text-petal-ink-soft mb-2">
+                <Calendar className="w-4 h-4" />
+                <span>預約 {formatDateTime(request.scheduledTime, tz, { alwaysShowTz: true })}</span>
+              </div>
+            )}
+            <p className="text-petal-ink text-sm leading-relaxed whitespace-pre-wrap break-words">
+              {request.messageContent}
+            </p>
+            <div className="text-xs text-petal-muted mt-2">
+              發送於 {formatDateTime(request.createdAt, tz)}
+              {request.expiresAt && (
+                <> ・效期至 {formatDateTime(request.expiresAt, tz)}</>
+              )}
+            </div>
+          </section>
+
+          {/* Response (if responded) */}
+          {!isPending && (request.responseMessage || request.alternativeType || request.alternativeContent || request.alternativeScheduledTime) && (
+            <section className="rounded-xl border border-petal-rule-soft bg-petal-cream-2/40 p-4 space-y-3">
+              <div className="flex items-center gap-2">
+                <MessageSquareHeart className="w-4 h-4 text-petal-rose-deep" />
+                <div className="text-sm font-medium text-petal-ink">{responseTitle}</div>
+              </div>
+
+              {request.responseMessage && (
+                <p className="text-sm text-petal-ink leading-relaxed whitespace-pre-wrap break-words">
+                  {request.responseMessage}
+                </p>
+              )}
+
+              {(request.alternativeType || request.alternativeContent || request.alternativeScheduledTime) && (
+                <div className="rounded-lg border border-petal-rule-soft bg-white p-3 space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-xs uppercase tracking-[0.12em] text-petal-muted">
+                    <Sparkles className="w-3.5 h-3.5" />
+                    <span>建議的替代方式</span>
+                  </div>
+                  {request.alternativeType && (
+                    <div className="text-xs text-petal-muted">
+                      類型：<span className="text-petal-ink">{ALTERNATIVE_CATEGORY_LABEL[request.alternativeType] || request.alternativeType}</span>
+                    </div>
+                  )}
+                  {request.alternativeContent && (
+                    <div className="text-sm text-petal-ink">
+                      {request.alternativeContent}
+                    </div>
+                  )}
+                  {request.alternativeScheduledTime && (
+                    <div className="inline-flex items-center gap-1.5 text-sm text-petal-ink">
+                      <Calendar className="w-4 h-4 text-petal-rose-deep" />
+                      <span>改到 {formatDateTime(request.alternativeScheduledTime, tz, { alwaysShowTz: true })}</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {request.respondedAt && (
+                <div className="text-xs text-petal-muted">
+                  回應於 {formatDateTime(request.respondedAt, tz)}
+                </div>
+              )}
+            </section>
+          )}
+
+          {/* Empty rejected state (responded with no message) */}
+          {isRejected && !request.responseMessage && !request.alternativeContent && !request.alternativeScheduledTime && (
+            <p className="text-sm text-petal-muted italic">對方沒有附上額外訊息。</p>
+          )}
+
+          {/* Action panel — only for received pending */}
+          {direction === 'received' && isPending && (
+            <section>
+              <div className="text-xs uppercase tracking-[0.12em] text-petal-muted mb-2">如何回應</div>
+              <IntimacyRequestActionPanel request={request} onResponded={onResponded} />
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IntimacyRequestDetailModal;

--- a/src/components/IntimacyRequestForm.tsx
+++ b/src/components/IntimacyRequestForm.tsx
@@ -3,6 +3,9 @@ import { Heart, Clock, Send, Sparkles, X } from 'lucide-react';
 import { apiService } from '../services/api';
 import type { IntimacyTemplate } from '../services/api';
 import { useScrollLock } from '../hooks/useScrollLock';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatDateTime, localInputToIsoInTz } from '../utils/datetime';
+import { getTimezoneShortLabel } from '../utils/timezone-options';
 
 interface IntimacyRequestFormProps {
   isOpen: boolean;
@@ -24,6 +27,7 @@ const IntimacyRequestForm: React.FC<IntimacyRequestFormProps> = ({
   const [templates, setTemplates] = useState<IntimacyTemplate[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const tz = useTimezone();
 
   const categories = [
     { id: 'compliment', name: '甜蜜讚美', emoji: '💕', description: '發送溫馨的讚美和愛意給伴侶' },
@@ -87,7 +91,7 @@ const IntimacyRequestForm: React.FC<IntimacyRequestFormProps> = ({
         requestType: selectedCategory === 'compliment' ? 'compliment' : selectedCategory === 'reconciliation' ? 'reconciliation' : requestType,
         roleplayCategory: selectedCategory !== 'custom' && selectedCategory !== 'compliment' && selectedCategory !== 'reconciliation' ? selectedCategory : undefined,
         scheduledTime: requestType === 'scheduled' && scheduledTime ?
-          new Date(scheduledTime).toISOString() : undefined,
+          localInputToIsoInTz(scheduledTime, tz) : undefined,
       });
 
       onSuccess();
@@ -361,7 +365,7 @@ const IntimacyRequestForm: React.FC<IntimacyRequestFormProps> = ({
                 {requestType === 'scheduled' && (
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-2">
-                      預約時間
+                      預約時間（以 {getTimezoneShortLabel(tz)} 顯示）
                     </label>
                     <input
                       type="datetime-local"
@@ -369,6 +373,9 @@ const IntimacyRequestForm: React.FC<IntimacyRequestFormProps> = ({
                       onChange={(e) => setScheduledTime(e.target.value)}
                       className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent"
                     />
+                    <p className="mt-1 text-xs text-gray-500">
+                      💡 雙方都會看到此時間以共用時區（{getTimezoneShortLabel(tz)}）為準，可在設定中調整。
+                    </p>
                   </div>
                 )}
 
@@ -431,7 +438,7 @@ const IntimacyRequestForm: React.FC<IntimacyRequestFormProps> = ({
                     {requestType === 'scheduled' && scheduledTime && (
                       <div className="mt-3 flex items-center space-x-2 text-sm text-gray-600">
                         <Clock className="w-4 h-4" />
-                        <span>預約時間：{new Date(scheduledTime).toLocaleString('zh-TW')}</span>
+                        <span>預約時間：{formatDateTime(localInputToIsoInTz(scheduledTime, tz), tz, { alwaysShowTz: true })}</span>
                       </div>
                     )}
                   </div>

--- a/src/components/IntimacyRequestsHistory.tsx
+++ b/src/components/IntimacyRequestsHistory.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Calendar, Inbox, Send } from 'lucide-react';
 import apiService from '../services/api';
 import type { IntimacyRequest, IntimacyRequestStats, IntimacyRequestNudge } from '../services/api';
-import IntimacyRequestActionPanel from './IntimacyRequestActionPanel';
+import IntimacyRequestDetailModal from './IntimacyRequestDetailModal';
 import { useTimezone } from '../contexts/TimezoneContext';
 import { formatDateTime } from '../utils/datetime';
 
@@ -38,6 +38,7 @@ export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = (
   const [emailFeedback, setEmailFeedback] = useState<FeedbackState | null>(null);
   const [tab, setTab] = useState<Tab>('received');
   const [tabInitialized, setTabInitialized] = useState(false);
+  const [detailOpenId, setDetailOpenId] = useState<string | null>(null);
   const me = authState.user?.nickname || '';
   const meId = authState.user?.id || '';
   const tz = useTimezone();
@@ -131,6 +132,9 @@ export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = (
 
   const activeItems = tab === 'received' ? received : sent;
   const activeEmptyText = tab === 'received' ? '尚無收到紀錄' : '尚無發送紀錄';
+  const detailRequest = detailOpenId
+    ? items.find((it) => it.id === detailOpenId) ?? null
+    : null;
 
   return (
     <div className="space-y-10">
@@ -186,12 +190,21 @@ export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = (
               items={activeItems}
               emptyText={activeEmptyText}
               tz={tz}
-              showActionsForPending={tab === 'received'}
-              onResponded={tab === 'received' ? fetchAll : undefined}
+              onOpenDetail={(id) => setDetailOpenId(id)}
             />
           </div>
         </>
       )}
+
+      <IntimacyRequestDetailModal
+        request={detailRequest}
+        direction={tab}
+        onClose={() => setDetailOpenId(null)}
+        onResponded={() => {
+          setDetailOpenId(null);
+          fetchAll();
+        }}
+      />
     </div>
   );
 };
@@ -396,7 +409,8 @@ function statusAccent(status: string): string {
   switch (status) {
     case 'accepted': return 'bg-petal-sage-deep';
     case 'pending': return 'bg-amber-400';
-    case 'rejected': return 'bg-petal-rose-deep';
+    case 'rejected':
+    case 'declined': return 'bg-petal-rose-deep';
     default: return 'bg-gray-300'; // expired or unknown
   }
 }
@@ -405,14 +419,15 @@ function statusBadgeClass(status: string): string {
   switch (status) {
     case 'accepted': return 'bg-green-100 text-green-700';
     case 'pending': return 'bg-yellow-100 text-yellow-700';
-    case 'rejected': return 'bg-red-100 text-red-700';
+    case 'rejected':
+    case 'declined': return 'bg-red-100 text-red-700';
     default: return 'bg-gray-100 text-gray-600';
   }
 }
 
 function translateStatus(status: string): string {
   if (status === 'accepted') return '已接受';
-  if (status === 'rejected') return '已拒絕';
+  if (status === 'rejected' || status === 'declined') return '已拒絕';
   if (status === 'expired') return '已過期';
   return '待回應';
 }
@@ -421,14 +436,12 @@ function RequestList({
   items,
   emptyText,
   tz,
-  showActionsForPending = false,
-  onResponded,
+  onOpenDetail,
 }: {
   items: IntimacyRequest[];
   emptyText: string;
   tz: string;
-  showActionsForPending?: boolean;
-  onResponded?: () => void;
+  onOpenDetail: (id: string) => void;
 }) {
   if (items.length === 0) {
     return <div className="text-gray-500 text-sm py-6 text-center font-display italic">{emptyText}</div>;
@@ -437,39 +450,46 @@ function RequestList({
   return (
     <ul className="space-y-3" role="tabpanel">
       {items.map((it) => {
-        const showActions = showActionsForPending && it.status === 'pending';
+        const hasAlternative = !!(it.alternativeContent || it.alternativeScheduledTime);
         return (
-          <li
-            key={it.id}
-            className="flex rounded-xl border border-petal-rule-soft bg-petal-cream-2/30 overflow-hidden"
-          >
-            <div className={`w-1 flex-shrink-0 ${statusAccent(it.status)}`} aria-hidden="true" />
-            <div className="flex-1 p-4">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                  {it.scheduledTime && (
-                    <div className="inline-flex items-center gap-1.5 text-sm text-petal-ink-soft mb-2">
-                      <Calendar className="w-4 h-4" />
-                      <span>預約 {formatDateTime(it.scheduledTime, tz, { alwaysShowTz: true })}</span>
+          <li key={it.id}>
+            <button
+              type="button"
+              onClick={() => onOpenDetail(it.id)}
+              data-testid="intimacy-card"
+              className="w-full text-left flex rounded-xl border border-petal-rule-soft bg-petal-cream-2/30 overflow-hidden hover:bg-petal-cream-2/60 transition-colors focus:outline-none focus:ring-2 focus:ring-petal-rose-deep/40"
+            >
+              <div className={`w-1 flex-shrink-0 ${statusAccent(it.status)}`} aria-hidden="true" />
+              <div className="flex-1 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    {it.scheduledTime && (
+                      <div className="inline-flex items-center gap-1.5 text-sm text-petal-ink-soft mb-2">
+                        <Calendar className="w-4 h-4" />
+                        <span>預約 {formatDateTime(it.scheduledTime, tz, { alwaysShowTz: true })}</span>
+                      </div>
+                    )}
+                    <div className="text-petal-ink text-sm leading-relaxed break-words">{it.messageContent}</div>
+                    {hasAlternative && (
+                      <div className="mt-2 inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full bg-petal-rose-soft text-petal-rose-deep">
+                        對方提了替代方式
+                        {it.alternativeScheduledTime && (
+                          <> · 改到 {formatDateTime(it.alternativeScheduledTime, tz)}</>
+                        )}
+                      </div>
+                    )}
+                    <div className="text-xs text-petal-muted mt-2">
+                      發送於 {formatDateTime(it.createdAt, tz)}
                     </div>
-                  )}
-                  <div className="text-petal-ink text-sm leading-relaxed break-words">{it.messageContent}</div>
-                  <div className="text-xs text-petal-muted mt-2">
-                    發送於 {formatDateTime(it.createdAt, tz)}
                   </div>
+                  <span
+                    className={`text-xs whitespace-nowrap flex-shrink-0 min-w-[4.5rem] inline-flex items-center justify-center text-center px-2 py-1 rounded-full ${statusBadgeClass(it.status)}`}
+                  >
+                    {translateStatus(it.status)}
+                  </span>
                 </div>
-                <span
-                  className={`text-xs whitespace-nowrap flex-shrink-0 min-w-[4.5rem] inline-flex items-center justify-center text-center px-2 py-1 rounded-full ${statusBadgeClass(it.status)}`}
-                >
-                  {translateStatus(it.status)}
-                </span>
               </div>
-              {showActions && onResponded && (
-                <div className="mt-3 pt-3 border-t border-petal-rule-soft">
-                  <IntimacyRequestActionPanel request={it} onResponded={onResponded} />
-                </div>
-              )}
-            </div>
+            </button>
           </li>
         );
       })}

--- a/src/components/IntimacyRequestsHistory.tsx
+++ b/src/components/IntimacyRequestsHistory.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Calendar, Inbox, Send } from 'lucide-react';
 import apiService from '../services/api';
 import type { IntimacyRequest, IntimacyRequestStats, IntimacyRequestNudge } from '../services/api';
 import IntimacyRequestActionPanel from './IntimacyRequestActionPanel';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatDateTime } from '../utils/datetime';
 
 interface User {
   id: string;
@@ -23,8 +26,9 @@ interface IntimacyRequestsHistoryProps {
 }
 
 type FeedbackState = { type: 'success' | 'error'; message: string };
+type Tab = 'received' | 'sent';
 
-export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = ({ authState, partnerNickname: partnerNicknameOverride }) => {
+export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = ({ authState }) => {
   const [items, setItems] = useState<IntimacyRequest[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -32,9 +36,11 @@ export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = (
   const [nudge, setNudge] = useState<IntimacyRequestNudge | null>(null);
   const [sendingEmail, setSendingEmail] = useState(false);
   const [emailFeedback, setEmailFeedback] = useState<FeedbackState | null>(null);
+  const [tab, setTab] = useState<Tab>('received');
+  const [tabInitialized, setTabInitialized] = useState(false);
   const me = authState.user?.nickname || '';
   const meId = authState.user?.id || '';
-  const partnerNickname = partnerNicknameOverride || authState.user?.partnerNickname || '';
+  const tz = useTimezone();
 
   const fetchAll = useCallback(async () => {
     try {
@@ -71,26 +77,30 @@ export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = (
     const s: IntimacyRequest[] = [];
     const r: IntimacyRequest[] = [];
     items.forEach((it) => {
-      // Use direction field from backend if available, fallback to nickname comparison
       if (it.direction === 'sent') {
         s.push(it);
       } else if (it.direction === 'received') {
         r.push(it);
-      } else {
-        // Fallback: categorize by id or nickname if direction is not available
-        if (it.senderId && it.senderId === meId) {
-          s.push(it);
-        } else if (it.receiverId && it.receiverId === meId) {
-          r.push(it);
-        } else if (it.senderNickname === me) {
-          s.push(it);
-        } else if (it.receiverNickname === me) {
-          r.push(it);
-        }
+      } else if (it.senderId && it.senderId === meId) {
+        s.push(it);
+      } else if (it.receiverId && it.receiverId === meId) {
+        r.push(it);
+      } else if (it.senderNickname === me) {
+        s.push(it);
+      } else if (it.receiverNickname === me) {
+        r.push(it);
       }
     });
     return { sent: s, received: r };
   }, [items, me, meId]);
+
+  // Smart default: open on 我收到的 when there's something actionable; otherwise 我發送的.
+  useEffect(() => {
+    if (tabInitialized || loading || items.length === 0) return;
+    const hasPendingReceived = received.some((r) => r.status === 'pending');
+    setTab(hasPendingReceived ? 'received' : sent.length > 0 ? 'sent' : 'received');
+    setTabInitialized(true);
+  }, [tabInitialized, loading, items.length, received, sent]);
 
   const handleSendNudgeEmail = useCallback(async () => {
     if (!nudge?.message) {
@@ -118,6 +128,9 @@ export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = (
       <div className="text-center py-10 text-gray-500">請先登入以查看歷史親密邀請</div>
     );
   }
+
+  const activeItems = tab === 'received' ? received : sent;
+  const activeEmptyText = tab === 'received' ? '尚無收到紀錄' : '尚無發送紀錄';
 
   return (
     <div className="space-y-10">
@@ -151,33 +164,61 @@ export const IntimacyRequestsHistory: React.FC<IntimacyRequestsHistoryProps> = (
             sendingEmail={sendingEmail}
             feedback={emailFeedback}
           />
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-white rounded-2xl shadow-lg p-6">
-              <h3 className="text-lg font-bold text-gray-800 mb-4">我發送的</h3>
-              <RequestList
-                items={sent}
-                emptyText="尚無發送紀錄"
-                meId={meId}
-                partnerNickname={partnerNickname}
+          <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+            <nav className="flex flex-wrap gap-2 mb-5 border-b border-petal-rule pb-3" role="tablist" aria-label="親密邀請紀錄">
+              <TabButton
+                active={tab === 'received'}
+                onClick={() => setTab('received')}
+                icon={Inbox}
+                label="我收到的"
+                count={received.length}
               />
-            </div>
-            <div className="bg-white rounded-2xl shadow-lg p-6">
-              <h3 className="text-lg font-bold text-gray-800 mb-4">我收到的</h3>
-              <RequestList
-                items={received}
-                emptyText="尚無收到紀錄"
-                meId={meId}
-                partnerNickname={partnerNickname}
-                showActionsForPending
-                onResponded={fetchAll}
+              <TabButton
+                active={tab === 'sent'}
+                onClick={() => setTab('sent')}
+                icon={Send}
+                label="我發送的"
+                count={sent.length}
               />
-            </div>
+            </nav>
+
+            <RequestList
+              items={activeItems}
+              emptyText={activeEmptyText}
+              tz={tz}
+              showActionsForPending={tab === 'received'}
+              onResponded={tab === 'received' ? fetchAll : undefined}
+            />
           </div>
         </>
       )}
     </div>
   );
 };
+
+interface TabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  icon: typeof Inbox;
+  label: string;
+  count: number;
+}
+
+function TabButton({ active, onClick, icon: Icon, label, count }: TabButtonProps) {
+  const base = 'flex items-center gap-2 px-4 py-2 rounded-full text-sm transition-colors border';
+  const cls = active
+    ? 'bg-petal-ink text-petal-cream border-petal-ink'
+    : 'bg-transparent text-petal-ink border-petal-rule hover:bg-petal-sage/20';
+  return (
+    <button type="button" role="tab" aria-selected={active} onClick={onClick} className={`${base} ${cls}`}>
+      <Icon className="w-4 h-4" />
+      <span>{label}</span>
+      <span className={`text-xs px-1.5 rounded-full ${active ? 'bg-petal-cream/20 text-petal-cream' : 'bg-petal-cream-2 text-petal-muted'}`}>
+        {count}
+      </span>
+    </button>
+  );
+}
 
 function StatsOverview({
   stats,
@@ -351,58 +392,22 @@ function buildInvitationInsights(stats: IntimacyRequestStats): string[] {
   return insights.slice(0, 4);
 }
 
-function RequestList({
-  items,
-  emptyText,
-  meId,
-  partnerNickname,
-  showActionsForPending = false,
-  onResponded,
-}: {
-  items: IntimacyRequest[];
-  emptyText: string;
-  meId: string;
-  partnerNickname?: string;
-  showActionsForPending?: boolean;
-  onResponded?: () => void;
-}) {
-  if (items.length === 0) {
-    return <div className="text-gray-500 text-sm">{emptyText}</div>;
+function statusAccent(status: string): string {
+  switch (status) {
+    case 'accepted': return 'bg-petal-sage-deep';
+    case 'pending': return 'bg-amber-400';
+    case 'rejected': return 'bg-petal-rose-deep';
+    default: return 'bg-gray-300'; // expired or unknown
   }
+}
 
-  return (
-    <ul className="divide-y divide-gray-100">
-      {items.map((it) => {
-        const { senderLabel, receiverLabel } = resolveRequestLabels({
-          item: it,
-          meId,
-          partnerNickname,
-        });
-        const showActions = showActionsForPending && it.status === 'pending';
-        return (
-          <li key={it.id} className="py-3">
-            <div className="flex items-start justify-between">
-              <div>
-                <div className="text-sm text-gray-600">
-                  <span className="font-medium text-gray-800">{senderLabel}</span>
-                  <span className="mx-1">→</span>
-                  <span className="font-medium text-gray-800">{receiverLabel}</span>
-                </div>
-                <div className="text-gray-700 text-sm mt-1">{it.messageContent}</div>
-                <div className="text-xs text-gray-400 mt-1">{new Date(it.createdAt).toLocaleString('zh-TW')}</div>
-              </div>
-              <span className={`text-xs px-2 py-1 rounded-full ${
-                it.status === 'accepted' ? 'bg-green-100 text-green-700' : it.status === 'pending' ? 'bg-yellow-100 text-yellow-700' : 'bg-red-100 text-red-700'
-              }`}>{translateStatus(it.status)}</span>
-            </div>
-            {showActions && onResponded && (
-              <IntimacyRequestActionPanel request={it} onResponded={onResponded} />
-            )}
-          </li>
-        );
-      })}
-    </ul>
-  );
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'accepted': return 'bg-green-100 text-green-700';
+    case 'pending': return 'bg-yellow-100 text-yellow-700';
+    case 'rejected': return 'bg-red-100 text-red-700';
+    default: return 'bg-gray-100 text-gray-600';
+  }
 }
 
 function translateStatus(status: string): string {
@@ -412,49 +417,64 @@ function translateStatus(status: string): string {
   return '待回應';
 }
 
-function resolveRequestLabels({
-  item,
-  meId,
-  partnerNickname,
+function RequestList({
+  items,
+  emptyText,
+  tz,
+  showActionsForPending = false,
+  onResponded,
 }: {
-  item: IntimacyRequest;
-  meId: string;
-  partnerNickname?: string;
+  items: IntimacyRequest[];
+  emptyText: string;
+  tz: string;
+  showActionsForPending?: boolean;
+  onResponded?: () => void;
 }) {
-  const fallbackPartner = partnerNickname || '伴侶';
-
-  if (item.direction === 'sent') {
-    return {
-      senderLabel: '你',
-      receiverLabel: partnerNickname || item.receiverNickname || fallbackPartner,
-    };
+  if (items.length === 0) {
+    return <div className="text-gray-500 text-sm py-6 text-center font-display italic">{emptyText}</div>;
   }
 
-  if (item.direction === 'received') {
-    return {
-      senderLabel: partnerNickname || item.senderNickname || fallbackPartner,
-      receiverLabel: '你',
-    };
-  }
-
-  if (item.senderId && item.senderId === meId) {
-    return {
-      senderLabel: '你',
-      receiverLabel: partnerNickname || item.receiverNickname || fallbackPartner,
-    };
-  }
-
-  if (item.receiverId && item.receiverId === meId) {
-    return {
-      senderLabel: partnerNickname || item.senderNickname || fallbackPartner,
-      receiverLabel: '你',
-    };
-  }
-
-  return {
-    senderLabel: item.senderNickname || fallbackPartner,
-    receiverLabel: item.receiverNickname || fallbackPartner,
-  };
+  return (
+    <ul className="space-y-3" role="tabpanel">
+      {items.map((it) => {
+        const showActions = showActionsForPending && it.status === 'pending';
+        return (
+          <li
+            key={it.id}
+            className="flex rounded-xl border border-petal-rule-soft bg-petal-cream-2/30 overflow-hidden"
+          >
+            <div className={`w-1 flex-shrink-0 ${statusAccent(it.status)}`} aria-hidden="true" />
+            <div className="flex-1 p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  {it.scheduledTime && (
+                    <div className="inline-flex items-center gap-1.5 text-sm text-petal-ink-soft mb-2">
+                      <Calendar className="w-4 h-4" />
+                      <span>預約 {formatDateTime(it.scheduledTime, tz, { alwaysShowTz: true })}</span>
+                    </div>
+                  )}
+                  <div className="text-petal-ink text-sm leading-relaxed break-words">{it.messageContent}</div>
+                  <div className="text-xs text-petal-muted mt-2">
+                    發送於 {formatDateTime(it.createdAt, tz)}
+                  </div>
+                </div>
+                <span
+                  className={`text-xs whitespace-nowrap flex-shrink-0 min-w-[4.5rem] inline-flex items-center justify-center text-center px-2 py-1 rounded-full ${statusBadgeClass(it.status)}`}
+                >
+                  {translateStatus(it.status)}
+                </span>
+              </div>
+              {showActions && onResponded && (
+                <div className="mt-3 pt-3 border-t border-petal-rule-soft">
+                  <IntimacyRequestActionPanel request={it} onResponded={onResponded} />
+                </div>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
 }
 
 export default IntimacyRequestsHistory;

--- a/src/components/NotificationInbox.tsx
+++ b/src/components/NotificationInbox.tsx
@@ -3,6 +3,8 @@ import { Bell, X } from 'lucide-react';
 import { apiService } from '../services/api';
 import type { Notification } from '../services/api';
 import { useScrollLock } from '../hooks/useScrollLock';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatRelativeOrDate } from '../utils/datetime';
 
 interface NotificationInboxProps {
   isOpen: boolean;
@@ -22,6 +24,7 @@ const NotificationInbox: React.FC<NotificationInboxProps> = ({
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const tz = useTimezone();
 
   const fetchNotifications = useCallback(async () => {
     try {
@@ -78,20 +81,7 @@ const NotificationInbox: React.FC<NotificationInboxProps> = ({
     onClose();
   };
 
-  const formatTimeAgo = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / (1000 * 60));
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    if (diffMins < 1) return '剛剛';
-    if (diffMins < 60) return `${diffMins}分鐘前`;
-    if (diffHours < 24) return `${diffHours}小時前`;
-    if (diffDays < 7) return `${diffDays}天前`;
-    return date.toLocaleDateString('zh-TW');
-  };
+  const formatTimeAgo = (dateString: string) => formatRelativeOrDate(dateString, tz);
 
   useScrollLock(isOpen);
 

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { User, Users, CheckCircle, Trash2 } from 'lucide-react';
 import { apiService, type CycleRecord } from '../services/api';
 import { averageCycleLength, predictNextPeriodStart, ovulationWindow, computeCycleLengths } from '../utils/cycle';
+import { TIMEZONE_OPTIONS } from '../utils/timezone-options';
 
 interface Nicknames {
   partner1: string;
@@ -28,6 +29,9 @@ interface User {
   birth_date?: string | null;
   email_notifications_enabled?: boolean;
   cycle_tracking_enabled?: boolean;
+  timezone?: string | null;
+  couplePrimaryTimezone?: string | null;
+  partnerTimezone?: string | null;
   partnerId?: string;
   partnerCode?: string;
   partnerNickname?: string;
@@ -159,6 +163,15 @@ const SettingsView: React.FC<SettingsViewProps> = ({
   const [cycleTrackingEnabled, setCycleTrackingEnabled] = useState<boolean>(false);
   const [isSavingCyclePref, setIsSavingCyclePref] = useState<boolean>(false);
 
+  // Timezone settings — per-user and couple-level primary
+  const browserTz = (() => {
+    try { return Intl.DateTimeFormat().resolvedOptions().timeZone || ''; } catch { return ''; }
+  })();
+  const [userTimezone, setUserTimezone] = useState<string>('');
+  const [couplePrimaryTimezone, setCouplePrimaryTimezone] = useState<string>('');
+  const [isSavingUserTz, setIsSavingUserTz] = useState<boolean>(false);
+  const [isSavingCoupleTz, setIsSavingCoupleTz] = useState<boolean>(false);
+
   // Email invitation states
   const [recipientEmail, setRecipientEmail] = useState('');
   const [invitationMessage, setInvitationMessage] = useState('');
@@ -195,6 +208,100 @@ const SettingsView: React.FC<SettingsViewProps> = ({
       setCycleTrackingEnabled(pref);
     }
   }, [authState.user?.cycle_tracking_enabled]);
+
+  useEffect(() => {
+    setUserTimezone(authState.user?.timezone || '');
+  }, [authState.user?.timezone]);
+
+  useEffect(() => {
+    setCouplePrimaryTimezone(authState.user?.couplePrimaryTimezone || '');
+  }, [authState.user?.couplePrimaryTimezone]);
+
+  const handleUpdateUserTimezone = async (next: string) => {
+    const previous = userTimezone;
+    setUserTimezone(next);
+    setIsSavingUserTz(true);
+    try {
+      await apiService.updateUserTimezone(next || null);
+      // First-user-wins default: if no couple primary is set yet, adopt this value.
+      let adoptedAsPrimary = false;
+      if (next && !authState.user?.couplePrimaryTimezone && authState.partnerConnected) {
+        try {
+          await apiService.updateCouplePrimaryTimezone(next);
+          adoptedAsPrimary = true;
+        } catch {
+          // Non-fatal; the user can set it manually below.
+        }
+      }
+      if (authState.user && onAuthStateUpdate) {
+        const updated = {
+          ...authState,
+          user: {
+            ...authState.user,
+            timezone: next || null,
+            ...(adoptedAsPrimary ? { couplePrimaryTimezone: next } : {}),
+          },
+        };
+        onAuthStateUpdate(updated);
+        localStorage.setItem('authState', JSON.stringify(updated));
+        localStorage.setItem('authUser', JSON.stringify(updated.user));
+      }
+      if (adoptedAsPrimary) setCouplePrimaryTimezone(next);
+      showNotification({
+        type: 'success',
+        title: '已更新',
+        message: adoptedAsPrimary ? '我的時區與共用時區已同步設定' : '我的時區已更新',
+        duration: 4000,
+      });
+    } catch (err) {
+      setUserTimezone(previous);
+      showNotification({
+        type: 'error',
+        title: '更新失敗',
+        message: (err as Error)?.message || '無法更新時區設定',
+        duration: 5000,
+      });
+    } finally {
+      setIsSavingUserTz(false);
+    }
+  };
+
+  const handleUpdateCouplePrimaryTimezone = async (next: string) => {
+    const previous = couplePrimaryTimezone;
+    setCouplePrimaryTimezone(next);
+    setIsSavingCoupleTz(true);
+    try {
+      await apiService.updateCouplePrimaryTimezone(next || null);
+      if (authState.user && onAuthStateUpdate) {
+        const updated = {
+          ...authState,
+          user: {
+            ...authState.user,
+            couplePrimaryTimezone: next || null,
+          },
+        };
+        onAuthStateUpdate(updated);
+        localStorage.setItem('authState', JSON.stringify(updated));
+        localStorage.setItem('authUser', JSON.stringify(updated.user));
+      }
+      showNotification({
+        type: 'success',
+        title: '已更新',
+        message: '共用時區已更新',
+        duration: 4000,
+      });
+    } catch (err) {
+      setCouplePrimaryTimezone(previous);
+      showNotification({
+        type: 'error',
+        title: '更新失敗',
+        message: (err as Error)?.message || '無法更新共用時區設定',
+        duration: 5000,
+      });
+    } finally {
+      setIsSavingCoupleTz(false);
+    }
+  };
 
   const handleToggleCycleTracking = async (next: boolean) => {
     const previous = cycleTrackingEnabled;
@@ -703,6 +810,79 @@ const SettingsView: React.FC<SettingsViewProps> = ({
           </div>
         </div>
       </div>
+
+      {/* Timezone Settings */}
+      <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+        <h3 className="text-lg font-bold text-gray-800 mb-4">我的時區</h3>
+        <div className="space-y-3">
+          <label htmlFor="user-timezone" className="block text-sm font-medium text-gray-700">
+            選擇你所在的時區
+          </label>
+          <select
+            id="user-timezone"
+            data-testid="user-timezone-select"
+            value={userTimezone}
+            disabled={isSavingUserTz}
+            onChange={(e) => handleUpdateUserTimezone(e.target.value)}
+            className="w-full sm:max-w-xs p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent bg-white"
+          >
+            <option value="">
+              {browserTz ? `使用裝置時區（${browserTz}）` : '使用裝置預設時區'}
+            </option>
+            {TIMEZONE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500">
+            💡 用於協助雙方協調時間。若伴侶尚未設定共用時區，我們會以你的時區作為預設。
+          </p>
+        </div>
+      </div>
+
+      {authState.partnerConnected && (
+        <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+          <h3 className="text-lg font-bold text-gray-800 mb-1">共用時區</h3>
+          <p className="text-xs text-gray-500 mb-4">
+            用於排程親密邀請、共同事件等時間顯示，雙方都會以此時區看到相同的時間。
+          </p>
+          <div className="space-y-3">
+            <select
+              data-testid="couple-primary-timezone-select"
+              value={couplePrimaryTimezone}
+              disabled={isSavingCoupleTz}
+              onChange={(e) => handleUpdateCouplePrimaryTimezone(e.target.value)}
+              className="w-full sm:max-w-xs p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-transparent bg-white"
+            >
+              <option value="">尚未設定（依各自裝置）</option>
+              {TIMEZONE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+            <div className="flex flex-wrap gap-2">
+              {authState.user?.timezone && (
+                <button
+                  type="button"
+                  onClick={() => handleUpdateCouplePrimaryTimezone(authState.user!.timezone!)}
+                  disabled={isSavingCoupleTz}
+                  className="px-3 py-1.5 text-xs rounded-full border border-petal-rule bg-petal-cream-2 text-petal-ink hover:bg-petal-sage/20 transition-colors disabled:opacity-50"
+                >
+                  套用我的時區
+                </button>
+              )}
+              {authState.user?.partnerTimezone && (
+                <button
+                  type="button"
+                  onClick={() => handleUpdateCouplePrimaryTimezone(authState.user!.partnerTimezone!)}
+                  disabled={isSavingCoupleTz}
+                  className="px-3 py-1.5 text-xs rounded-full border border-petal-rule bg-petal-cream-2 text-petal-ink hover:bg-petal-sage/20 transition-colors disabled:opacity-50"
+                >
+                  套用伴侶的時區
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Email Notification Preferences */}
       <div className="bg-white rounded-2xl shadow-lg p-6">

--- a/src/components/WallPostThread.tsx
+++ b/src/components/WallPostThread.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Send, Trash2 } from 'lucide-react';
 import { apiService, type WallReply } from '../services/api';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatRelativeOrDate } from '../utils/datetime';
 
 interface WallPostThreadProps {
   postId: string;
@@ -9,19 +11,8 @@ interface WallPostThreadProps {
   onError?: (message: string) => void;
 }
 
-const formatTime = (iso: string) => {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return '剛剛';
-  if (diffMin < 60) return `${diffMin} 分鐘前`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr} 小時前`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay} 天前`;
-  return date.toLocaleDateString('zh-TW', { month: 'short', day: 'numeric' });
-};
+const formatTime = (iso: string, tz: string) =>
+  formatRelativeOrDate(iso, tz, { month: 'short', day: 'numeric' });
 
 const WallPostThread: React.FC<WallPostThreadProps> = ({
   postId,
@@ -33,6 +24,7 @@ const WallPostThread: React.FC<WallPostThreadProps> = ({
   const [loading, setLoading] = useState(true);
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+  const tz = useTimezone();
 
   useEffect(() => {
     let cancelled = false;
@@ -121,7 +113,7 @@ const WallPostThread: React.FC<WallPostThreadProps> = ({
                   {reply.author_nickname || (isOwn ? '我' : '對方')}
                 </span>
                 <span className="font-body text-[11px] text-petal-muted">
-                  {formatTime(reply.created_at)}
+                  {formatTime(reply.created_at, tz)}
                 </span>
               </div>
               {isOwn && (

--- a/src/components/WallView.tsx
+++ b/src/components/WallView.tsx
@@ -19,6 +19,8 @@ import {
 import type { Notification } from './ErrorNotification';
 import WallPostComposer, { type WallExample } from './WallPostComposer';
 import WallPostThread from './WallPostThread';
+import { useTimezone } from '../contexts/TimezoneContext';
+import { formatRelativeOrDate } from '../utils/datetime';
 
 interface WallViewProps {
   authState: {
@@ -41,23 +43,8 @@ const FILTER_TABS: { id: WallFilter; label: string; icon: string }[] = [
   { id: 'mood', label: '帶心情', icon: '💭' },
 ];
 
-const formatTime = (iso: string) => {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return '剛剛';
-  if (diffMin < 60) return `${diffMin} 分鐘前`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr} 小時前`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay} 天前`;
-  return date.toLocaleDateString('zh-TW', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-};
+const formatTime = (iso: string, tz: string) =>
+  formatRelativeOrDate(iso, tz, { year: 'numeric', month: 'short', day: 'numeric' });
 
 const WallView: React.FC<WallViewProps> = ({
   authState,
@@ -68,6 +55,7 @@ const WallView: React.FC<WallViewProps> = ({
 }) => {
   const userId = authState.user?.id;
   const tutorialKey = `wall_tutorial_seen_${userId || 'anon'}`;
+  const tz = useTimezone();
 
   const [posts, setPosts] = useState<WallPost[]>([]);
   const [loading, setLoading] = useState(true);
@@ -216,7 +204,7 @@ const WallView: React.FC<WallViewProps> = ({
               </span>
             )}
             <span className="font-body text-[11px] text-petal-muted">
-              · {formatTime(post.created_at)}
+              · {formatTime(post.created_at, tz)}
             </span>
           </div>
           {isOwn && (

--- a/src/contexts/TimezoneContext.ts
+++ b/src/contexts/TimezoneContext.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+// Holds the IANA timezone string used to render shared timestamps (intimacy
+// invitations, events, wall posts, etc.). Populated from couple.primaryTimezone
+// in App.tsx with a sensible browser-default fallback.
+const TimezoneContext = createContext<string>('Asia/Taipei');
+
+export const TimezoneProvider = TimezoneContext.Provider;
+
+export function useTimezone(): string {
+  return useContext(TimezoneContext);
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -74,6 +74,9 @@ interface CoupleResponse {
   firstIntimacyPlace?: string;
   user1Nickname: string;
   user2Nickname?: string;
+  user1Timezone?: string;
+  user2Timezone?: string;
+  primaryTimezone?: string;
   createdAt: string;
   pairingCode?: string;
   user1Id?: string;
@@ -1207,8 +1210,11 @@ class ApiService {
       first_intimacy_place?: string;
       user1_id?: string;
       user1_nickname?: string;
+      user1_timezone?: string;
       user2_id?: string;
       user2_nickname?: string;
+      user2_timezone?: string;
+      primary_timezone?: string;
       created_at?: string;
       pairing_code?: string;
       pending_conflicts?: Record<string, { inviter: string; accepter: string }>;
@@ -1222,8 +1228,11 @@ class ApiService {
       firstDate: typedData?.first_date,
       user1Id: typedData?.user1_id,
       user1Nickname: typedData?.user1_nickname || '',
+      user1Timezone: typedData?.user1_timezone,
       user2Id: typedData?.user2_id,
       user2Nickname: typedData?.user2_nickname,
+      user2Timezone: typedData?.user2_timezone,
+      primaryTimezone: typedData?.primary_timezone,
       firstKissDate: typedData?.first_kiss_date,
       firstKissPlace: typedData?.first_kiss_place,
       firstIntimacyDate: typedData?.first_intimacy_date,
@@ -1288,6 +1297,24 @@ class ApiService {
     } catch (error: unknown) {
       console.error('Failed to update user birth date:', error);
       throw new Error((error as ApiErrorResponse)?.message || '更新生日失敗');
+    }
+  }
+
+  async updateUserTimezone(timezone: string | null): Promise<void> {
+    try {
+      await apiClient.put('/auth/user/timezone', { timezone });
+    } catch (error: unknown) {
+      console.error('Failed to update user timezone:', error);
+      throw new Error((error as ApiErrorResponse)?.message || '更新時區失敗');
+    }
+  }
+
+  async updateCouplePrimaryTimezone(timezone: string | null): Promise<void> {
+    try {
+      await apiClient.put('/couples/primary-timezone', { primary_timezone: timezone });
+    } catch (error: unknown) {
+      console.error('Failed to update couple primary timezone:', error);
+      throw new Error((error as ApiErrorResponse)?.message || '更新共用時區失敗');
     }
   }
 

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,172 @@
+// Timezone-aware formatters for shared timestamps (intimacy, events, wall, etc.).
+// All formatters honor an IANA timezone (e.g. 'Asia/Taipei') passed by the caller,
+// which typically comes from <TimezoneProvider> populated with the couple's primary tz.
+
+import { TIMEZONE_OPTIONS, getTimezoneShortLabel } from './timezone-options';
+
+export interface DateTimeOptions {
+  // When true, always append " (短標籤)" even if tz matches the viewer's browser tz.
+  // Used for scheduled times where the timezone must be unambiguous.
+  alwaysShowTz?: boolean;
+  withYear?: boolean;
+}
+
+function browserTz(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+function shouldAppendTz(tz: string, opts?: DateTimeOptions): boolean {
+  if (opts?.alwaysShowTz) return true;
+  return tz !== browserTz();
+}
+
+function formatPartsZh(date: Date, opts: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('zh-TW', opts).format(date);
+}
+
+function safeDate(value: string | Date): Date | null {
+  const d = typeof value === 'string' ? new Date(value) : value;
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+// "5/30 (五) 20:00 (台北)" — full date + time + optional timezone suffix.
+export function formatDateTime(value: string | Date, tz: string, opts?: DateTimeOptions): string {
+  const date = safeDate(value);
+  if (!date) return '';
+  const dateOpts: Intl.DateTimeFormatOptions = opts?.withYear
+    ? { year: 'numeric', month: 'numeric', day: 'numeric', timeZone: tz }
+    : { month: 'numeric', day: 'numeric', timeZone: tz };
+  const dateStr = formatPartsZh(date, dateOpts);
+  const weekday = formatPartsZh(date, { weekday: 'narrow', timeZone: tz });
+  const timeStr = formatPartsZh(date, { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: tz });
+  const suffix = shouldAppendTz(tz, opts) ? ` (${getTimezoneShortLabel(tz)})` : '';
+  return `${dateStr} (${weekday}) ${timeStr}${suffix}`;
+}
+
+// "5/30 (五)" — date only, no time component.
+export function formatDate(
+  value: string | Date,
+  tz: string,
+  opts?: Intl.DateTimeFormatOptions & { withWeekday?: boolean }
+): string {
+  const date = safeDate(value);
+  if (!date) return '';
+  const { withWeekday = true, ...rest } = opts || {};
+  const baseOpts: Intl.DateTimeFormatOptions = Object.keys(rest).length
+    ? { ...rest, timeZone: tz }
+    : { month: 'numeric', day: 'numeric', timeZone: tz };
+  const dateStr = formatPartsZh(date, baseOpts);
+  if (!withWeekday) return dateStr;
+  const weekday = formatPartsZh(date, { weekday: 'narrow', timeZone: tz });
+  return `${dateStr} (${weekday})`;
+}
+
+// "20:00"
+export function formatTimeOnly(value: string | Date, tz: string): string {
+  const date = safeDate(value);
+  if (!date) return '';
+  return formatPartsZh(date, { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: tz });
+}
+
+// "2026年5月" — calendar header.
+export function formatMonthYear(value: string | Date, tz: string): string {
+  const date = safeDate(value);
+  if (!date) return '';
+  return formatPartsZh(date, { year: 'numeric', month: 'long', timeZone: tz });
+}
+
+// Relative for recent timestamps, falls back to absolute date for older.
+// Replaces the duplicated logic in WallPostThread / WallView / NotificationInbox.
+export function formatRelativeOrDate(
+  value: string | Date,
+  tz: string,
+  fallbackOpts?: Intl.DateTimeFormatOptions
+): string {
+  const date = safeDate(value);
+  if (!date) return '';
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+
+  if (diffMs < minute) return '剛剛';
+  if (diffMs < hour) return `${Math.floor(diffMs / minute)} 分鐘前`;
+  if (diffMs < day) return `${Math.floor(diffMs / hour)} 小時前`;
+  if (diffMs < week) return `${Math.floor(diffMs / day)} 天前`;
+
+  const opts: Intl.DateTimeFormatOptions = fallbackOpts
+    ? { ...fallbackOpts, timeZone: tz }
+    : { year: 'numeric', month: 'numeric', day: 'numeric', timeZone: tz };
+  return formatPartsZh(date, opts);
+}
+
+// Parses a `<input type="datetime-local">` value "YYYY-MM-DDTHH:mm" interpreted in tz,
+// returns the corresponding UTC ISO string. Survives DST transitions because the offset
+// is computed at the candidate UTC moment.
+export function localInputToIsoInTz(localValue: string, tz: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(localValue);
+  if (!m) return '';
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const d = Number(m[3]);
+  const h = Number(m[4]);
+  const mi = Number(m[5]);
+  const s = Number(m[6] || 0);
+
+  // Treat the wall-clock as if it were UTC; this is just a candidate instant.
+  const candidateUtc = Date.UTC(y, mo - 1, d, h, mi, s);
+  // Compute what wall-clock that candidate maps to inside tz.
+  // The diff is exactly tz's UTC offset at that moment.
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  });
+  const parts = dtf.formatToParts(new Date(candidateUtc));
+  const get = (t: string) => Number(parts.find((p) => p.type === t)?.value);
+  const tzY = get('year');
+  const tzMo = get('month');
+  const tzD = get('day');
+  let tzH = get('hour');
+  const tzMi = get('minute');
+  const tzS = get('second');
+  if (tzH === 24) tzH = 0; // en-US sometimes returns 24 at midnight.
+  const tzWallAsUtc = Date.UTC(tzY, tzMo - 1, tzD, tzH, tzMi, tzS);
+  const offsetMs = tzWallAsUtc - candidateUtc;
+  return new Date(candidateUtc - offsetMs).toISOString();
+}
+
+// Inverse of localInputToIsoInTz — for prefilling `<input type="datetime-local">`.
+export function isoToLocalInputInTz(iso: string, tz: string): string {
+  const date = safeDate(iso);
+  if (!date) return '';
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+  const parts = dtf.formatToParts(date);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value || '';
+  let h = get('hour');
+  if (h === '24') h = '00';
+  return `${get('year')}-${get('month')}-${get('day')}T${h}:${get('minute')}`;
+}
+
+// Fallback chain: couple primary → viewer's own → browser default.
+export function getPrimaryTimezone(state: {
+  couplePrimaryTz?: string | null;
+  userTz?: string | null;
+}): string {
+  if (state.couplePrimaryTz) return state.couplePrimaryTz;
+  if (state.userTz) return state.userTz;
+  return browserTz();
+}
+
+// Re-export so callers don't need both modules.
+export { TIMEZONE_OPTIONS, getTimezoneShortLabel };

--- a/src/utils/timezone-options.ts
+++ b/src/utils/timezone-options.ts
@@ -1,0 +1,26 @@
+// Curated IANA timezone list shared by the Settings dropdown and the date formatter.
+// Keep in sync with lib/timezone-options.js (server-side validation).
+
+export interface TimezoneOption {
+  value: string;
+  label: string;
+  short: string;
+}
+
+export const TIMEZONE_OPTIONS: ReadonlyArray<TimezoneOption> = [
+  { value: 'Asia/Taipei',         label: '台北 (GMT+8)',     short: '台北' },
+  { value: 'Asia/Hong_Kong',      label: '香港 (GMT+8)',     short: '香港' },
+  { value: 'Asia/Shanghai',       label: '中國 (GMT+8)',     short: '上海' },
+  { value: 'Asia/Tokyo',          label: '東京 (GMT+9)',     short: '東京' },
+  { value: 'Asia/Seoul',          label: '首爾 (GMT+9)',     short: '首爾' },
+  { value: 'Asia/Singapore',      label: '新加坡 (GMT+8)',   short: '新加坡' },
+  { value: 'America/Los_Angeles', label: '美西 (PT)',        short: '美西' },
+  { value: 'America/New_York',    label: '美東 (ET)',        short: '美東' },
+  { value: 'Europe/London',       label: '倫敦 (GMT/BST)',   short: '倫敦' },
+  { value: 'Europe/Paris',        label: '歐陸 (CET)',       short: '歐陸' },
+  { value: 'Australia/Sydney',    label: '雪梨 (AET)',       short: '雪梨' },
+];
+
+export function getTimezoneShortLabel(value: string): string {
+  return TIMEZONE_OPTIONS.find((o) => o.value === value)?.short ?? value;
+}


### PR DESCRIPTION
## Summary

Two changes shipped together:

### A. 親密邀請紀錄 layout redesign
- **Tabs replace the side-by-side grid** — 我收到的 / 我發送的 with count badges; smart default opens 我收到的 when there's a pending row, else 我發送的.
- **Cards with status-colored left accent stripe** (sage / amber / rose / gray) — status is scannable at a glance instead of buried in a divide-y row.
- **Drops the redundant 馮迪索 → 你 line** — the tab context already conveys direction.
- **Status badge wrapping fix** — `whitespace-nowrap flex-shrink-0 min-w-[4.5rem]` so 待回\n應 no longer breaks across two lines on narrow widths or with long messages.
- **預約時間 chip on every card** that has `scheduledTime`, on both directions and all statuses. Previously only visible to receivers on pending rows inside `IntimacyRequestActionPanel`; that duplicate is removed.

### B. Couple timezone setting, applied app-wide to shared timestamps
Two partners in different timezones now see consistent times. Each user picks their own tz in Settings; the couple picks one as the **primary** that drives capture and display of all shared timestamps.

- Migration `035` adds `users.timezone` + `couples.primary_timezone` (both nullable IANA).
- Backend `PUT /auth/user/timezone` + `PUT /couples/primary-timezone` validated against a curated allow-list (`lib/timezone-options.js`).
- `src/utils/datetime.ts` — Intl-only formatters (`formatDateTime`, `formatDate`, `formatTimeOnly`, `formatMonthYear`, `formatRelativeOrDate`) and DST-correct round-trippers (`localInputToIsoInTz` / `isoToLocalInputInTz`) for `datetime-local` inputs.
- `TimezoneProvider` context at the App root pulls from `couple.primary_timezone` → `user.timezone` → browser default.
- SettingsView adds 我的時區 + 共用時區 cards (with 套用我的時區 / 套用伴侶的時區 quick-fills). First-user-wins: when a user sets their own tz and the couple primary is null, the couple primary adopts it.
- IntimacyRequestForm interprets the datetime-local in the primary tz on submit; preview shows the explicit tz suffix.
- Formatters rolled out across every shared-timestamp surface: `IntimacyRequestsHistory`, `App.tsx` (love moment + calendar header), `EventHistoryList`, `EventDetail`, `WallPostThread`, `WallView`, `NotificationInbox`, `AchievementsView`.

Journey `DATE` columns (anniversary, first-meet, etc.) are intentionally left as-is — no time, no timezone meaning.

## Verification

- Typecheck: `tsc --noEmit` clean.
- Build: `vite build` succeeds.
- Lint: clean on changed files (only pre-existing warnings remain in App.tsx).
- DST + cross-tz round-trip math: `node scripts/test-datetime.cjs` → **11/11 passed** across Asia/Taipei, America/Los_Angeles (PDT + PST), Europe/London (BST + GMT), and a Taipei↔LA scenario.
- Local e2e not run (worktree has no `.env.test`); CI gates them on push.

## Test plan

- [ ] Settings → 我的時區: change picker, verify persists across reload; if couple primary is null, it auto-adopts.
- [ ] Settings → 共用時區: change picker; 套用我的時區 / 套用伴侶的時區 buttons populate from each side.
- [ ] As Taipei sender, schedule an intimacy invitation for tomorrow 20:00. As LA viewer, confirm the card reads `預約 5/31 (六) 20:00 (台北)` — NOT 05:00 PT.
- [ ] LA viewer switches couple primary to `America/Los_Angeles`. Same invitation reloads as `5/30 (五) 05:00`. Underlying ISO unchanged.
- [ ] Resize viewport to ~320px width and verify 已接受 / 待回應 / 已拒絕 / 已過期 never wrap to two lines, even with a long message.
- [ ] Confirm 預約時間 appears once on a received pending card (inside the card, not duplicated in the action panel).
- [ ] CI: e2e suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)