### PR TITLE
Marketplace UI polish: no image cropping, rename to 創作市集, themed dropdowns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Project conventions
+
+Notes for anyone (human or AI) working in this repo. Keep this file short and
+current.
+
+## Image handling
+
+**Never crop images.** Always show the full image.
+
+- Use `object-contain` (not `object-cover`) on `<img>` elements and avoid
+  fixed crops / background-image `cover`.
+- It's fine to place a contained image inside a fixed-size slot (e.g.
+  `aspect-video`); give the slot a neutral background (we use
+  `bg-petal-cream-2`) so it shows behind images whose aspect ratio differs
+  from the slot. The image is letterboxed/pillarboxed, never cut off.
+- The shared `renderThumb` helper in `src/components/RoleplayView.tsx`
+  defaults to `'contain'` for this reason — keep it that way.

--- a/routes/marketplace.js
+++ b/routes/marketplace.js
@@ -92,7 +92,7 @@ router.get(
       });
     } catch (error) {
       logDbError('Marketplace list error:', error, { user_id: req.user?.id });
-      res.status(500).json(errorResponseBody('無法載入 Marketplace 劇本', error));
+      res.status(500).json(errorResponseBody('無法載入創作市集劇本', error));
     }
   }
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4974,10 +4974,10 @@ const LoveTimeApp = () => {
                 />
                 <div className="flex-1">
                   <div className="font-body text-sm font-medium text-petal-ink">
-                    分享到 Marketplace
+                    分享到創作市集
                   </div>
                   <p className="font-display italic font-light text-xs text-petal-muted mt-0.5 leading-relaxed">
-                    開啟後，其他使用者可以在 Marketplace 看到、評分、收藏這個劇本。
+                    開啟後，其他使用者可以在創作市集看到、評分、收藏這個劇本。
                   </p>
                 </div>
               </label>

--- a/src/components/MarketplaceScriptDetail.tsx
+++ b/src/components/MarketplaceScriptDetail.tsx
@@ -165,7 +165,7 @@ export default function MarketplaceScriptDetail({
       >
         <div className="sticky top-0 z-10 bg-petal-cream/95 backdrop-blur-sm flex items-center justify-between px-5 sm:px-8 py-3 border-b border-petal-rule">
           <span className="font-body text-[11px] font-medium uppercase tracking-[0.16em] text-petal-muted">
-            — Marketplace 劇本
+            — 創作市集 劇本
           </span>
           <button
             type="button"

--- a/src/components/PetalSelect.tsx
+++ b/src/components/PetalSelect.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+
+export interface PetalSelectOption {
+  value: string;
+  label: string;
+}
+
+interface PetalSelectProps {
+  value: string;
+  options: PetalSelectOption[];
+  onChange: (value: string) => void;
+  /** Leading icon shown inside the pill trigger. */
+  icon?: React.ReactNode;
+  /** Accessible label for the trigger button. */
+  ariaLabel?: string;
+  /** data-testid for the trigger (mirrors the old <select> testid). */
+  testId?: string;
+  /** Prefix for per-option testids, e.g. `marketplace-sort` → `…-option-rating`. */
+  optionTestIdPrefix?: string;
+}
+
+/**
+ * Themed dropdown that replaces the native <select> so the option list follows
+ * the "Soft Petal" palette instead of the browser's dark native popup. Built
+ * from the same trigger + absolute panel + click-catcher overlay pattern used
+ * by the user menu in Header.tsx.
+ */
+export default function PetalSelect({
+  value,
+  options,
+  onChange,
+  icon,
+  ariaLabel,
+  testId,
+  optionTestIdPrefix,
+}: PetalSelectProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        data-testid={testId}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-petal-rule bg-white hover:border-petal-rose transition-colors focus:outline-none focus:border-petal-rose-deep"
+      >
+        {icon}
+        <span className="font-body text-[13px] text-petal-ink">
+          {selected?.label ?? ''}
+        </span>
+        <ChevronDown
+          className={`w-3.5 h-3.5 text-petal-muted transition-transform ${open ? 'rotate-180' : ''}`}
+          strokeWidth={1.5}
+        />
+      </button>
+
+      {open && (
+        <>
+          {/* Click-catcher to close on outside click */}
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <ul
+            role="listbox"
+            className="absolute left-0 mt-2 min-w-[10rem] bg-petal-cream rounded-md shadow-petal border border-petal-rule z-50 py-1 overflow-hidden"
+          >
+            {options.map((opt) => {
+              const isSelected = opt.value === value;
+              return (
+                <li key={opt.value} role="option" aria-selected={isSelected}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onChange(opt.value);
+                      setOpen(false);
+                    }}
+                    data-testid={optionTestIdPrefix ? `${optionTestIdPrefix}-option-${opt.value}` : undefined}
+                    className={`w-full flex items-center justify-between gap-2 px-3 py-1.5 text-left font-body text-[13px] transition-colors ${
+                      isSelected
+                        ? 'bg-petal-rose-soft text-petal-rose-deep'
+                        : 'text-petal-ink hover:bg-petal-cream-2'
+                    }`}
+                  >
+                    <span>{opt.label}</span>
+                    {isSelected && <Check className="w-3.5 h-3.5" strokeWidth={2} />}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/RoleplayView.tsx
+++ b/src/components/RoleplayView.tsx
@@ -6,6 +6,7 @@ import { apiService } from '../services/api';
 import type { MarketplaceScript } from '../services/api';
 import StarRating from './StarRating';
 import MarketplaceScriptDetail from './MarketplaceScriptDetail';
+import PetalSelect from './PetalSelect';
 
 interface RoleplayScript {
   id: string;
@@ -118,7 +119,7 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
     } catch (err) {
       showNotification({
         type: 'error',
-        title: '無法載入 Marketplace',
+        title: '無法載入創作市集',
         message: (err as Error)?.message || '請稍後再試',
         duration: 4000,
       });
@@ -271,10 +272,11 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
   };
 
   // Renders either the real thumbnail, or the editorial placeholder if image
-  // is missing / fails to load. `fit` controls the <img> object-fit — use
-  // 'contain' for the modal hero (show the whole image) and 'cover' for grid
-  // cards (fill the slot edge-to-edge).
-  const renderThumb = (script: RoleplayScript, className: string, fit: 'cover' | 'contain' = 'cover') => {
+  // is missing / fails to load. `fit` controls the <img> object-fit. We default
+  // to 'contain' so the full image is always visible — never crop images (see
+  // CLAUDE.md). The slot background (bg-petal-cream-2) shows behind contained
+  // images that don't match the slot's aspect ratio.
+  const renderThumb = (script: RoleplayScript, className: string, fit: 'cover' | 'contain' = 'contain') => {
     if (!script.image) {
       return <ScriptThumbPlaceholder category={script.category} title={script.title} className={className} />;
     }
@@ -315,7 +317,7 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
       <div className="flex gap-1 mb-6 border-b border-petal-rule">
         {([
           { id: 'mine' as const, label: '我的劇本', icon: <FileText className="w-3.5 h-3.5" strokeWidth={1.5} /> },
-          { id: 'marketplace' as const, label: 'Marketplace', icon: <Store className="w-3.5 h-3.5" strokeWidth={1.5} /> },
+          { id: 'marketplace' as const, label: '創作市集', icon: <Store className="w-3.5 h-3.5" strokeWidth={1.5} /> },
         ]).map((t) => {
           const isActive = mainTab === t.id;
           return (
@@ -503,7 +505,7 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
           <div className="mb-10" data-testid="roleplay-marketplace-favorites-section">
             <h3 className="font-display text-2xl font-medium tracking-tight text-petal-ink mb-6 flex items-center">
               <Heart className="w-4 h-4 mr-2 text-petal-rose-deep fill-petal-rose-deep" strokeWidth={1.5} />
-              來自 <em className="not-italic font-light italic text-pink-600 mx-1">Marketplace</em> 的收藏
+              來自 <em className="not-italic font-light italic text-pink-600 mx-1">創作市集</em> 的收藏
               <span className="font-display italic font-light text-sm text-petal-muted ml-2">({favoritedMarketplace.length})</span>
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -617,34 +619,34 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
       {mainTab === 'marketplace' && (
         <div data-testid="roleplay-marketplace-tab">
           <div className="flex flex-wrap gap-2 mb-6">
-            <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-petal-rule bg-white">
-              <ArrowDownWideNarrow className="w-3.5 h-3.5 text-petal-muted" strokeWidth={1.5} />
-              <select
-                value={marketplaceSort}
-                onChange={(e) => setMarketplaceSort(e.target.value as 'rating' | 'recent' | 'popular')}
-                data-testid="marketplace-sort"
-                className="bg-transparent font-body text-[13px] text-petal-ink focus:outline-none"
-              >
-                <option value="rating">評分最高</option>
-                <option value="popular">最熱門</option>
-                <option value="recent">最新</option>
-              </select>
-            </div>
-            <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-petal-rule bg-white">
-              <Filter className="w-3.5 h-3.5 text-petal-muted" strokeWidth={1.5} />
-              <select
-                value={marketplaceCategory}
-                onChange={(e) => setMarketplaceCategory(e.target.value as typeof marketplaceCategory)}
-                data-testid="marketplace-category"
-                className="bg-transparent font-body text-[13px] text-petal-ink focus:outline-none"
-              >
-                <option value="all">全部分類</option>
-                <option value="romantic">浪漫</option>
-                <option value="adventurous">冒險</option>
-                <option value="school">校園</option>
-                <option value="bold">大膽</option>
-              </select>
-            </div>
+            <PetalSelect
+              value={marketplaceSort}
+              onChange={(v) => setMarketplaceSort(v as 'rating' | 'recent' | 'popular')}
+              testId="marketplace-sort"
+              optionTestIdPrefix="marketplace-sort"
+              ariaLabel="排序方式"
+              icon={<ArrowDownWideNarrow className="w-3.5 h-3.5 text-petal-muted" strokeWidth={1.5} />}
+              options={[
+                { value: 'rating', label: '評分最高' },
+                { value: 'popular', label: '最熱門' },
+                { value: 'recent', label: '最新' },
+              ]}
+            />
+            <PetalSelect
+              value={marketplaceCategory}
+              onChange={(v) => setMarketplaceCategory(v as typeof marketplaceCategory)}
+              testId="marketplace-category"
+              optionTestIdPrefix="marketplace-category"
+              ariaLabel="分類篩選"
+              icon={<Filter className="w-3.5 h-3.5 text-petal-muted" strokeWidth={1.5} />}
+              options={[
+                { value: 'all', label: '全部分類' },
+                { value: 'romantic', label: '浪漫' },
+                { value: 'adventurous', label: '冒險' },
+                { value: 'school', label: '校園' },
+                { value: 'bold', label: '大膽' },
+              ]}
+            />
           </div>
 
           {marketplaceLoading ? (
@@ -665,7 +667,7 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
                   onClick={() => setMarketplaceDetailId(m.id)}
                 >
                   <div className="relative aspect-video bg-petal-cream-2 rounded-md mb-3 overflow-hidden">
-                    {renderThumb(marketplaceToRoleplay(m), 'w-full h-full', 'cover')}
+                    {renderThumb(marketplaceToRoleplay(m), 'w-full h-full', 'contain')}
                   </div>
                   <h4 className="font-display text-base font-medium tracking-tight text-petal-ink mb-1 truncate">
                     {m.title}

--- a/tests/marketplace-flow.spec.ts
+++ b/tests/marketplace-flow.spec.ts
@@ -118,7 +118,10 @@ test.describe('Marketplace — public script sharing + ratings + favorites', () 
     await expect(page.getByTestId('marketplace-grid')).toBeVisible({ timeout: 5000 });
 
     // 4. Switch the sort dropdown to "最新" so the new script bubbles to the top.
-    await page.getByTestId('marketplace-sort').selectOption('recent');
+    //    The sort control is a custom themed dropdown (not a native <select>),
+    //    so open the trigger then click the option.
+    await page.getByTestId('marketplace-sort').click();
+    await page.getByTestId('marketplace-sort-option-recent').click();
     await page.waitForResponse(
       (r) => r.url().includes('/api/marketplace/scripts') && r.request().method() === 'GET',
       { timeout: 10000 }


### PR DESCRIPTION
## Summary

Three related polish fixes in the Roleplay → 創作市集 area.

### 1. Images no longer crop (+ recorded as a project convention)
- `renderThumb` in `RoleplayView.tsx` now defaults to `object-contain` (was `object-cover`), and the marketplace grid card passes `'contain'`. Thumbnails across the grid, script list, and favorites now show the **full image**, letterboxed against the existing `bg-petal-cream-2` slot background — never cut off.
- Added **`CLAUDE.md`** with an "Image handling" section so the no-crop rule is remembered for future work.

### 2. Renamed "Marketplace" → "創作市集"
All user-facing text: nav tab, script-detail modal eyebrow, favorites header, the share toggle label + description (`App.tsx`), and load-error messages (frontend + `routes/marketplace.js`). Routes, component/type names, and `data-testid`s are intentionally left unchanged.

### 3. Redesigned the filter dropdowns (the "black rectangle")
The dark rectangle was the browser's native `<select>` popup. Replaced both filters with a new themed **`PetalSelect`** component (`src/components/PetalSelect.tsx`) — a pill trigger + chevron and an absolutely-positioned panel in the Soft Petal palette (cream bg, rounded, petal border, rose-highlighted selected option with a checkmark). Closes on outside-click or Escape, and keeps the original `marketplace-sort` / `marketplace-category` test ids.

## Testing
- `tsc -b` ✅
- `vite build` ✅
- `eslint` ✅ (only pre-existing, unrelated warnings)
- Updated `tests/marketplace-flow.spec.ts` to open the trigger and click the option (the old `selectOption` no longer applies). Playwright e2e was **not** executed in this environment (needs a running server/DB).

https://claude.ai/code/session_01C6JraKakoaba4oMFNYMNdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6JraKakoaba4oMFNYMNdu)_