### PR TITLE
fix(cycle): persist cycle-tracking pref across login; calendar polish

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -115,7 +115,7 @@ router.post('/login', [
 
     // Find user
     const userResult = await db.query(
-      'SELECT id, nickname, email, gender, birth_date, timezone, password_hash, created_at FROM users WHERE email = $1',
+      'SELECT id, nickname, email, gender, birth_date, timezone, email_notifications_enabled, cycle_tracking_enabled, password_hash, created_at FROM users WHERE email = $1',
       [email]
     );
 
@@ -169,6 +169,8 @@ router.post('/login', [
         gender: user.gender,
         birth_date: user.birth_date,
         timezone: user.timezone,
+        email_notifications_enabled: user.email_notifications_enabled !== false,
+        cycle_tracking_enabled: user.cycle_tracking_enabled === true,
         created_at: user.created_at
       }
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -627,6 +627,8 @@ const LoveTimeApp = () => {
         gender?: 'male' | 'female' | 'other';
         birth_date?: string | null;
         timezone?: string | null;
+        email_notifications_enabled?: boolean;
+        cycle_tracking_enabled?: boolean;
         created_at?: string;
       };
 
@@ -637,6 +639,8 @@ const LoveTimeApp = () => {
         gender: userData.gender,
         birth_date: userData.birth_date,
         timezone: userData.timezone,
+        email_notifications_enabled: userData.email_notifications_enabled,
+        cycle_tracking_enabled: userData.cycle_tracking_enabled,
         partnerCode: generatePartnerCode(),
         createdAt: userData.created_at || new Date().toISOString()
       };

--- a/src/components/AchievementsView.tsx
+++ b/src/components/AchievementsView.tsx
@@ -560,13 +560,23 @@ export function CalendarHeatmap({ data, year, month, title, showMonthLabels = tr
                 </span>
               </div>
               {isPeriod && (
-                <span data-testid="cycle-period-dot" className="absolute top-0.5 left-0.5 w-1.5 h-1.5 rounded-full bg-red-500" title="月經" />
+                <span data-testid="cycle-period-dot" className="absolute top-0.5 left-0.5 w-2 h-2 rounded-full bg-red-500" title="月經" />
               )}
               {!isPeriod && isPredictedPeriod && (
-                <span data-testid="cycle-predicted-dot" className="absolute top-0.5 left-0.5 w-1.5 h-1.5 rounded-full border border-red-400" title="預測月經" />
+                <span data-testid="cycle-predicted-dot" className="absolute top-0.5 left-0.5 w-2 h-2 rounded-full border border-red-400" title="預測月經" />
               )}
               {isFertile && (
-                <span data-testid="cycle-fertile-dot" className="absolute bottom-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-emerald-500" title="適合備孕" />
+                <span data-testid="cycle-fertile-dot" className="absolute bottom-0.5 right-0.5 w-2 h-2 rounded-full bg-emerald-500" title="適合備孕" />
+              )}
+              {day.count > 0 && (
+                <span
+                  data-testid="intimacy-heart"
+                  className={`absolute top-0.5 right-0.5 flex items-center gap-px text-[9px] leading-none font-semibold ${day.count >= 3 ? 'text-white' : 'text-rose-500'}`}
+                  title={`${day.count} 次記錄`}
+                >
+                  <span aria-hidden="true">♥</span>
+                  {day.count}
+                </span>
               )}
               <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity z-20 whitespace-nowrap pointer-events-none">
                 {day.date.toLocaleDateString('zh-TW', { month: 'short', day: 'numeric' })}


### PR DESCRIPTION
- auth login now returns cycle_tracking_enabled + email_notifications_enabled (fetched in SELECT, normalized like /auth/me) so a fresh login no longer resets the 啟用週期追蹤 toggle to off
- App.tsx handleLogin carries both prefs onto the user object + persisted authState
- calendar: show ♥N intimacy-count badge in the day cell's free top-right corner (white on high-count cells, rose-500 otherwise)
- calendar: enlarge 月經/預測月經/適合備孕 dots from 6px to 8px