### PR TITLE
feat(therapists): human counselor directory, public signup, consultation chat

### DIFF
--- a/database/migrations/041_therapists.sql
+++ b/database/migrations/041_therapists.sql
@@ -1,0 +1,106 @@
+-- Human therapists (心理諮商師) directory + consultation requests.
+--
+-- This adds the "talk to a real, certified human" option alongside the
+-- existing (cheaper) AI rephrase feature. Therapists apply via a public sign-up
+-- form; applications land as 'pending' and only become visible in the browse
+-- list once an admin approves them (status = 'approved'). Users/couples then
+-- pick a therapist and send a consultation request.
+--
+-- Focus areas (family / couple / childhood / individual / sexuality /
+-- parenting / grief / anxiety) are stored as a TEXT[] so a therapist can list
+-- several and the browse page can filter by any one of them.
+
+CREATE TABLE IF NOT EXISTS therapists (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- The user account that submitted the application, if they were logged in.
+  -- Nullable so a therapist can apply without first creating a couples account.
+  user_id          UUID REFERENCES users(id) ON DELETE SET NULL,
+
+  -- Public profile
+  display_name     VARCHAR(120) NOT NULL,
+  title            VARCHAR(120),                 -- e.g. 諮商心理師 / 臨床心理師
+  license_no       VARCHAR(80),                  -- 證照字號 (shown only to admins)
+  focus_areas      TEXT[] NOT NULL DEFAULT '{}', -- family | couple | childhood | individual | sexuality | parenting | grief | anxiety
+  languages        TEXT[] NOT NULL DEFAULT '{}', -- e.g. {zh, en}
+  years_experience INTEGER,
+  bio              TEXT,
+  photo_url        TEXT,
+
+  -- Rate. Stored as integer TWD per session plus the session length so the
+  -- browse card can show "NT$1,800 / 50 分鐘".
+  rate_twd         INTEGER NOT NULL,
+  session_minutes  INTEGER NOT NULL DEFAULT 50,
+
+  -- Contact (private — used to reach the therapist, never shown in browse)
+  contact_email    VARCHAR(255) NOT NULL,
+  contact_phone    VARCHAR(40),
+
+  -- Moderation
+  status           VARCHAR(16) NOT NULL DEFAULT 'pending', -- pending | approved | rejected
+  reviewed_at      TIMESTAMP WITH TIME ZONE,
+  review_note      TEXT,
+
+  created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT therapists_rate_positive CHECK (rate_twd >= 0),
+  CONSTRAINT therapists_status_valid CHECK (status IN ('pending', 'approved', 'rejected'))
+);
+
+-- Browse list is "approved therapists, newest first"; the partial index keeps
+-- that query cheap as the rejected/pending rows pile up.
+CREATE INDEX IF NOT EXISTS idx_therapists_approved
+  ON therapists(created_at DESC)
+  WHERE status = 'approved';
+
+-- One consultation request per (user → therapist) interaction. couple_id is
+-- recorded when the requester is paired so the therapist knows it's a couple.
+CREATE TABLE IF NOT EXISTS therapist_consultations (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  therapist_id   UUID NOT NULL REFERENCES therapists(id) ON DELETE CASCADE,
+  requester_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  couple_id      UUID REFERENCES couples(id) ON DELETE SET NULL,
+
+  focus_area     VARCHAR(40),                 -- which area the request is about
+  message        TEXT,                        -- what the user/couple wants help with
+  contact_email  VARCHAR(255),                -- where the therapist should reply
+  preferred_time TIMESTAMP WITH TIME ZONE,    -- optional requested slot
+
+  status         VARCHAR(16) NOT NULL DEFAULT 'pending', -- pending | accepted | declined | completed | cancelled
+  responded_at   TIMESTAMP WITH TIME ZONE,
+  response_note  TEXT,
+
+  created_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT therapist_consultations_status_valid
+    CHECK (status IN ('pending', 'accepted', 'declined', 'completed', 'cancelled'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_therapist_consultations_requester
+  ON therapist_consultations(requester_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_therapist_consultations_therapist
+  ON therapist_consultations(therapist_id, created_at DESC);
+
+-- Seed a few approved therapists so the browse page is populated on first run.
+-- These are illustrative profiles; real applicants come through the sign-up form.
+INSERT INTO therapists
+  (display_name, title, focus_areas, languages, years_experience, bio,
+   rate_twd, session_minutes, contact_email, status, reviewed_at)
+VALUES
+  ('林書宇', '諮商心理師',
+   ARRAY['couple', 'family', 'sexuality'], ARRAY['zh', 'en'], 12,
+   '專注於伴侶溝通與親密關係修復，擅長以情緒取向治療（EFT）陪伴伴侶重建信任與連結。相信每段關係都值得被好好理解。',
+   1800, 50, 'shuyu.lin@example.com', 'approved', NOW()),
+  ('陳怡安', '臨床心理師',
+   ARRAY['individual', 'anxiety', 'childhood'], ARRAY['zh'], 8,
+   '陪伴成年人梳理童年經驗與焦慮情緒，找回自我價值感。以溫和、不批判的方式，與你一起慢慢來。',
+   1600, 50, 'yian.chen@example.com', 'approved', NOW()),
+  ('王柏睿', '諮商心理師',
+   ARRAY['couple', 'parenting', 'grief'], ARRAY['zh', 'en'], 15,
+   '協助伴侶在成為父母後重新校準關係，也陪伴經歷失落與悲傷的家庭。相信對話是改變的起點。',
+   2000, 60, 'borui.wang@example.com', 'approved', NOW()),
+  ('黃心妍', '諮商心理師',
+   ARRAY['family', 'childhood', 'individual'], ARRAY['zh'], 6,
+   '專長家庭關係與原生家庭議題，擅長陪伴年輕族群探索自我與界線。',
+   1400, 50, 'hsinyen.huang@example.com', 'approved', NOW());

--- a/database/migrations/042_consultation_chat.sql
+++ b/database/migrations/042_consultation_chat.sql
@@ -1,0 +1,23 @@
+-- Group chat for a consultation: the couple (both partners) + the therapist
+-- talk in one room. Messages can reference a recorded "event" (events table)
+-- so the conversation can be anchored to a specific past incident the couple
+-- logged.
+--
+-- The "room" is the consultation row itself (therapist_consultations); this
+-- table is just its message log. Who may read/post is computed in the route:
+-- the requester, anyone in the consultation's couple, or the therapist's
+-- linked user account.
+
+CREATE TABLE IF NOT EXISTS consultation_messages (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  consultation_id UUID NOT NULL REFERENCES therapist_consultations(id) ON DELETE CASCADE,
+  sender_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  body            TEXT NOT NULL CHECK (char_length(body) BETWEEN 1 AND 2000),
+  -- Optional anchor to a recorded event the couple is discussing. SET NULL so
+  -- deleting the event doesn't erase the chat history.
+  event_id        UUID REFERENCES events(id) ON DELETE SET NULL,
+  created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_consultation_messages_room
+  ON consultation_messages(consultation_id, created_at);

--- a/public/therapist-signup.html
+++ b/public/therapist-signup.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>成為諮商師 · Twogether</title>
+  <meta name="description" content="加入 Twogether，成為平台上的諮商心理師，陪伴伴侶與個人面對關係與情緒議題。" />
+  <style>
+    :root {
+      --ink: #2a2422;
+      --ink-soft: #5b524d;
+      --muted: #8a807c;
+      --cream: #fbf7f2;
+      --cream-2: #f2ebdf;
+      --rule: #e4dccf;
+      --rose: #b7635a;
+      --pink: #d4868a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", "Noto Sans TC", sans-serif;
+      background: var(--cream);
+      color: var(--ink);
+      line-height: 1.6;
+    }
+    .wrap { max-width: 720px; margin: 0 auto; padding: 32px 20px 80px; }
+    header { text-align: center; margin-bottom: 28px; }
+    .eyebrow { font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted); }
+    h1 { font-size: 30px; font-weight: 300; margin: 8px 0 6px; letter-spacing: -0.01em; }
+    h1 em { font-style: italic; color: var(--rose); }
+    .lede { color: var(--muted); font-size: 15px; margin: 0; }
+    .card { background: #fff; border: 1px solid var(--rule); border-radius: 12px; padding: 24px; box-shadow: 0 1px 2px rgba(0,0,0,0.03); }
+    label { display: block; font-size: 12px; font-weight: 600; color: var(--ink-soft); margin-bottom: 6px; }
+    .req { color: var(--rose); }
+    input[type=text], input[type=email], input[type=tel], input[type=number], textarea, select {
+      width: 100%; padding: 10px 12px; border: 1px solid var(--rule); border-radius: 8px;
+      font-size: 14px; font-family: inherit; background: var(--cream); color: var(--ink);
+    }
+    input:focus, textarea:focus, select:focus { outline: none; border-color: var(--ink); }
+    textarea { resize: vertical; min-height: 96px; }
+    .field { margin-bottom: 18px; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    .row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
+    .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+    .chip {
+      display: inline-flex; align-items: center; gap: 6px; padding: 7px 13px; border-radius: 999px;
+      border: 1px solid var(--rule); color: var(--ink-soft); font-size: 13px; cursor: pointer;
+      user-select: none; background: var(--cream); transition: all .12s;
+    }
+    .chip input { display: none; }
+    .chip.on { background: var(--ink); color: var(--cream); border-color: var(--ink); }
+    .submit {
+      width: 100%; padding: 13px; border: none; border-radius: 8px; background: var(--ink);
+      color: var(--cream); font-size: 15px; font-weight: 500; cursor: pointer; margin-top: 6px;
+    }
+    .submit:disabled { opacity: .5; cursor: default; }
+    .note { font-size: 13px; color: var(--muted); margin-top: 14px; text-align: center; }
+    .result { display: none; padding: 16px; border-radius: 8px; margin-bottom: 18px; font-size: 14px; }
+    .result.ok { display: block; background: #eef4ea; color: #3f6b3a; border: 1px solid #cfe0c5; }
+    .result.err { display: block; background: #f8ebe9; color: #9a3b33; border: 1px solid #ecccc7; }
+    a.back { display: inline-block; margin-top: 22px; color: var(--muted); font-size: 13px; text-decoration: none; }
+    a.back:hover { color: var(--ink); }
+    @media (max-width: 560px) { .row, .row-3 { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <div class="eyebrow">— Twogether 心理諮商</div>
+      <h1>成為 <em>諮商心理師</em></h1>
+      <p class="lede">加入平台，陪伴伴侶與個人面對關係與情緒議題。審核通過後，你的檔案會出現在諮商師列表中供使用者預約。</p>
+    </header>
+
+    <div class="card">
+      <div id="result" class="result"></div>
+      <form id="form">
+        <div class="row">
+          <div class="field">
+            <label>姓名 <span class="req">*</span></label>
+            <input type="text" name="displayName" maxlength="120" required />
+          </div>
+          <div class="field">
+            <label>職稱</label>
+            <input type="text" name="title" maxlength="120" placeholder="諮商心理師 / 臨床心理師" />
+          </div>
+        </div>
+
+        <div class="field">
+          <label>證照字號（僅供審核，不公開）</label>
+          <input type="text" name="licenseNo" maxlength="80" />
+        </div>
+
+        <div class="field">
+          <label>專長領域 <span class="req">*</span></label>
+          <div class="chips" id="focus">
+            <label class="chip"><input type="checkbox" value="couple" />💞 伴侶關係</label>
+            <label class="chip"><input type="checkbox" value="family" />🏡 家庭</label>
+            <label class="chip"><input type="checkbox" value="childhood" />🧸 童年/原生家庭</label>
+            <label class="chip"><input type="checkbox" value="individual" />🌱 個人成長</label>
+            <label class="chip"><input type="checkbox" value="sexuality" />🔥 性與親密</label>
+            <label class="chip"><input type="checkbox" value="parenting" />👶 親職教養</label>
+            <label class="chip"><input type="checkbox" value="grief" />🕊️ 悲傷失落</label>
+            <label class="chip"><input type="checkbox" value="anxiety" />🌧️ 焦慮憂鬱</label>
+          </div>
+        </div>
+
+        <div class="field">
+          <label>提供語言</label>
+          <div class="chips" id="langs">
+            <label class="chip on"><input type="checkbox" value="zh" checked />中文</label>
+            <label class="chip"><input type="checkbox" value="en" />English</label>
+            <label class="chip"><input type="checkbox" value="ja" />日本語</label>
+            <label class="chip"><input type="checkbox" value="ko" />한국어</label>
+          </div>
+        </div>
+
+        <div class="row-3">
+          <div class="field">
+            <label>年資</label>
+            <input type="number" name="yearsExperience" min="0" max="80" />
+          </div>
+          <div class="field">
+            <label>費率 (NT$) <span class="req">*</span></label>
+            <input type="number" name="rateTwd" min="0" max="100000" value="1600" required />
+          </div>
+          <div class="field">
+            <label>時長 (分)</label>
+            <input type="number" name="sessionMinutes" min="10" max="240" value="50" />
+          </div>
+        </div>
+
+        <div class="field">
+          <label>自我介紹</label>
+          <textarea name="bio" maxlength="2000" placeholder="你的取向、擅長陪伴的對象與議題…"></textarea>
+        </div>
+
+        <div class="row">
+          <div class="field">
+            <label>聯絡 Email <span class="req">*</span></label>
+            <input type="email" name="contactEmail" maxlength="255" required />
+          </div>
+          <div class="field">
+            <label>聯絡電話</label>
+            <input type="tel" name="contactPhone" maxlength="40" />
+          </div>
+        </div>
+
+        <button type="submit" class="submit" id="submit">送出申請</button>
+        <p class="note">送出後我們會在審核後與你聯繫。審核期間你的資料不會公開。</p>
+      </form>
+    </div>
+
+    <div style="text-align:center"><a class="back" href="/">← 回到 Twogether</a></div>
+  </div>
+
+  <script>
+    // Toggle chip visual state when its checkbox changes.
+    document.querySelectorAll('.chip').forEach(function (chip) {
+      var cb = chip.querySelector('input');
+      var sync = function () { chip.classList.toggle('on', cb.checked); };
+      cb.addEventListener('change', sync);
+      sync();
+    });
+
+    function collect(id) {
+      return Array.prototype.slice
+        .call(document.querySelectorAll('#' + id + ' input:checked'))
+        .map(function (i) { return i.value; });
+    }
+
+    var form = document.getElementById('form');
+    var result = document.getElementById('result');
+    var submit = document.getElementById('submit');
+
+    function show(kind, msg) {
+      result.className = 'result ' + kind;
+      result.textContent = msg;
+      result.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var fd = new FormData(form);
+      var focusAreas = collect('focus');
+      if (!fd.get('displayName').trim()) return show('err', '請填寫姓名');
+      if (focusAreas.length === 0) return show('err', '請至少選擇一個專長領域');
+      if (!fd.get('contactEmail').trim()) return show('err', '請填寫聯絡 Email');
+
+      var payload = {
+        displayName: fd.get('displayName').trim(),
+        title: fd.get('title').trim() || undefined,
+        licenseNo: fd.get('licenseNo').trim() || undefined,
+        focusAreas: focusAreas,
+        languages: collect('langs'),
+        yearsExperience: fd.get('yearsExperience') ? Number(fd.get('yearsExperience')) : undefined,
+        bio: fd.get('bio').trim() || undefined,
+        rateTwd: Number(fd.get('rateTwd')) || 0,
+        sessionMinutes: Number(fd.get('sessionMinutes')) || 50,
+        contactEmail: fd.get('contactEmail').trim(),
+        contactPhone: fd.get('contactPhone').trim() || undefined
+      };
+
+      submit.disabled = true;
+      submit.textContent = '送出中…';
+      fetch('/api/therapists/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+        .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, b: b }; }); })
+        .then(function (res) {
+          if (res.ok && res.b.success) {
+            form.reset();
+            document.querySelectorAll('.chip').forEach(function (c) {
+              var cb = c.querySelector('input'); c.classList.toggle('on', cb.checked);
+            });
+            show('ok', '✓ 申請已送出！我們會在審核通過後與你聯繫。');
+          } else {
+            show('err', (res.b && res.b.message) || '送出失敗，請稍後再試');
+          }
+        })
+        .catch(function () { show('err', '網路錯誤，請稍後再試'); })
+        .finally(function () { submit.disabled = false; submit.textContent = '送出申請'; });
+    });
+  </script>
+</body>
+</html>

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -563,6 +563,7 @@ const ADMIN_HTML = `<!doctype html>
       <button class="tab active" data-panel="funnel">漏斗</button>
       <button class="tab" data-panel="pages">頁面</button>
       <button class="tab" data-panel="retention">回訪</button>
+      <button class="tab" data-panel="therapists">諮商師</button>
     </div>
 
     <!-- Panel: Funnel (default) -->
@@ -621,6 +622,37 @@ const ADMIN_HTML = `<!doctype html>
 
       <h3 style="margin:20px 0 6px;font-weight:500;font-size:14px">DAU 趨勢（30 天）</h3>
       <svg id="dauSpark" class="sparkline" viewBox="0 0 480 60" preserveAspectRatio="none"></svg>
+    </div>
+
+    <!-- Panel: Therapists (approval queue) -->
+    <div class="panel" id="panel-therapists">
+      <p class="sub">諮商師申請審核。通過後檔案才會出現在使用者的諮商師列表中。</p>
+      <div class="controls">
+        <label>狀態
+          <select id="therapistStatus">
+            <option value="pending">待審核</option>
+            <option value="approved">已通過</option>
+            <option value="rejected">未通過</option>
+          </select>
+        </label>
+        <button id="therapistRefresh">重新整理</button>
+        <span class="muted" id="therapistStatusMsg"></span>
+      </div>
+      <div style="overflow-x:auto">
+        <table id="therapistsTable">
+          <thead>
+            <tr>
+              <th>姓名 / 職稱</th>
+              <th>專長</th>
+              <th class="num">費率</th>
+              <th>聯絡 / 證照</th>
+              <th>申請時間</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
     </div>
   </div>
 
@@ -813,6 +845,93 @@ const ADMIN_HTML = `<!doctype html>
           '</tr>';
       }).join('');
     }
+
+    // ── Therapists approval queue ──────────────────────────────────────────
+    var THERAPIST_FOCUS = {
+      couple: '伴侶關係', family: '家庭', childhood: '童年/原生家庭',
+      individual: '個人成長', sexuality: '性與親密', parenting: '親職教養',
+      grief: '悲傷失落', anxiety: '焦慮憂鬱'
+    };
+    function esc(s) {
+      return (s == null ? '' : String(s)).replace(/[<>&]/g, function (c) {
+        return { '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c];
+      });
+    }
+
+    async function loadTherapists() {
+      var status = $('therapistStatus').value;
+      $('therapistStatusMsg').textContent = '載入中…';
+      try {
+        var res = await fetch('/api/admin/therapists?status=' + encodeURIComponent(status));
+        if (!res.ok) throw new Error('therapists ' + res.status);
+        var body = await res.json();
+        renderTherapists(body.therapists || [], status);
+        $('therapistStatusMsg').textContent = '更新於 ' + new Date().toLocaleTimeString('zh-TW');
+      } catch (e) {
+        $('therapistStatusMsg').textContent = '載入失敗: ' + e.message;
+      }
+    }
+
+    function renderTherapists(rows, status) {
+      var tbody = document.querySelector('#therapistsTable tbody');
+      if (rows.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="6" class="muted">沒有資料</td></tr>';
+        return;
+      }
+      tbody.innerHTML = rows.map(function (t) {
+        var focus = (t.focus_areas || []).map(function (f) {
+          return '<span class="pill">' + esc(THERAPIST_FOCUS[f] || f) + '</span>';
+        }).join(' ');
+        var contact = esc(t.contact_email || '—') +
+          (t.license_no ? '<div class="muted" style="font-size:11px">證照: ' + esc(t.license_no) + '</div>' : '');
+        var actions = status === 'pending'
+          ? '<button data-act="approve" data-id="' + t.id + '">通過</button> ' +
+            '<button data-act="reject" data-id="' + t.id + '">退回</button>'
+          : '<span class="muted">' + (status === 'approved' ? '已通過' : '已退回') + '</span>';
+        return '<tr>' +
+          '<td><div>' + esc(t.display_name) + '</div><div class="muted" style="font-size:11px">' + esc(t.title || '') + '</div></td>' +
+          '<td>' + focus + '</td>' +
+          '<td class="num">NT$' + (t.rate_twd || 0).toLocaleString() + ' / ' + (t.session_minutes || 50) + '分</td>' +
+          '<td>' + contact + '</td>' +
+          '<td>' + fmtDate(t.created_at) + '</td>' +
+          '<td>' + actions + '</td>' +
+          '</tr>';
+      }).join('');
+
+      tbody.querySelectorAll('button[data-act]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          reviewTherapist(btn.getAttribute('data-id'), btn.getAttribute('data-act'), btn);
+        });
+      });
+    }
+
+    async function reviewTherapist(id, act, btn) {
+      btn.disabled = true;
+      try {
+        var res = await fetch('/api/admin/therapists/' + id + '/review', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: act })
+        });
+        if (!res.ok) throw new Error('review ' + res.status);
+        await loadTherapists();
+      } catch (e) {
+        btn.disabled = false;
+        $('therapistStatusMsg').textContent = '操作失敗: ' + e.message;
+      }
+    }
+
+    $('therapistRefresh').addEventListener('click', loadTherapists);
+    $('therapistStatus').addEventListener('change', loadTherapists);
+    // Lazy-load the queue the first time the tab is opened.
+    var therapistsLoaded = false;
+    document.querySelectorAll('.tab').forEach(function (btn) {
+      if (btn.getAttribute('data-panel') === 'therapists') {
+        btn.addEventListener('click', function () {
+          if (!therapistsLoaded) { therapistsLoaded = true; loadTherapists(); }
+        });
+      }
+    });
 
     $('apply').addEventListener('click', load);
     load();

--- a/routes/therapists.js
+++ b/routes/therapists.js
@@ -1,0 +1,486 @@
+// Human therapist (心理諮商師) directory + consultation requests.
+//
+// Two routers are exported:
+//   - router:      public/JWT endpoints mounted at /api/therapists
+//                  (browse approved therapists, apply to join, request a
+//                   consultation, list my own consultations/applications)
+//   - adminRouter: Basic-Auth gated endpoints mounted at /api/admin/therapists
+//                  (list pending applications, approve/reject)
+//
+// This is the "talk to a real human" option that sits alongside the existing
+// (cheaper) AI rephrase feature — the AI flow is untouched.
+
+const express = require('express');
+const { body, query: queryValidator, validationResult } = require('express-validator');
+const db = require('../database/db');
+const { authenticateToken, optionalAuth } = require('../middleware/auth');
+const { logInfo, logWarn, logError } = require('../lib/logger');
+
+const router = express.Router();
+const adminRouter = express.Router();
+
+const FOCUS_AREAS = [
+  'family',      // 家庭
+  'couple',      // 伴侶
+  'childhood',   // 童年/原生家庭
+  'individual',  // 個人成長
+  'sexuality',   // 性與親密
+  'parenting',   // 親職
+  'grief',       // 悲傷失落
+  'anxiety',     // 焦慮憂鬱
+];
+
+// Shape the public-facing therapist object. Never leaks license_no /
+// contact_* — those are private to the applicant and admins.
+const toPublicTherapist = (row) => ({
+  id: row.id,
+  displayName: row.display_name,
+  title: row.title,
+  focusAreas: row.focus_areas || [],
+  languages: row.languages || [],
+  yearsExperience: row.years_experience,
+  bio: row.bio,
+  photoUrl: row.photo_url,
+  rateTwd: row.rate_twd,
+  sessionMinutes: row.session_minutes,
+  createdAt: row.created_at,
+});
+
+const sanitizeStringArray = (value, allowList) => {
+  if (!Array.isArray(value)) return [];
+  const cleaned = value
+    .map((v) => (typeof v === 'string' ? v.trim() : ''))
+    .filter(Boolean);
+  const unique = [...new Set(cleaned)];
+  return allowList ? unique.filter((v) => allowList.includes(v)) : unique;
+};
+
+const handleValidation = (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ success: false, message: '驗證失敗', errors: errors.array() });
+    return false;
+  }
+  return true;
+};
+
+// Resolve a consultation row and decide whether `userId` may take part in its
+// chat. A participant is the requester, a member of the consultation's couple
+// (so BOTH partners can join the room), or the therapist's linked user account.
+// Returns null when the consultation doesn't exist.
+const loadConsultationAccess = async (consultationId, userId) => {
+  const result = await db.query(`
+    SELECT
+      tc.id, tc.therapist_id, tc.requester_id, tc.couple_id, tc.status,
+      t.user_id AS therapist_user_id, t.display_name AS therapist_name,
+      c.user1_id, c.user2_id
+    FROM therapist_consultations tc
+    JOIN therapists t ON t.id = tc.therapist_id
+    LEFT JOIN couples c ON c.id = tc.couple_id
+    WHERE tc.id = $1
+  `, [consultationId]);
+  if (result.rows.length === 0) return null;
+  const r = result.rows[0];
+  const isTherapist = Boolean(r.therapist_user_id) && r.therapist_user_id === userId;
+  const isCoupleMember = r.user1_id === userId || r.user2_id === userId;
+  const isParticipant = Boolean(isTherapist || isCoupleMember || r.requester_id === userId);
+  return { row: r, isParticipant, isTherapist, role: isTherapist ? 'therapist' : 'client' };
+};
+
+// --- Public browse -------------------------------------------------------
+
+// GET /api/therapists?focus=couple
+// List approved therapists, optionally filtered to one focus area.
+router.get('/', optionalAuth, [
+  queryValidator('focus').optional().isIn(FOCUS_AREAS).withMessage('focus 無效'),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const { focus } = req.query;
+    const params = [];
+    let sql = `SELECT * FROM therapists WHERE status = 'approved'`;
+    if (focus) {
+      params.push(focus);
+      sql += ` AND $${params.length} = ANY(focus_areas)`;
+    }
+    sql += ` ORDER BY created_at DESC`;
+    const result = await db.query(sql, params);
+    res.json({ success: true, therapists: result.rows.map(toPublicTherapist) });
+  } catch (error) {
+    logError('Failed to list therapists', { err: error.message });
+    res.status(500).json({ success: false, message: '無法取得諮商師列表' });
+  }
+});
+
+// GET /api/therapists/focus-areas — the canonical list (for filter chips).
+router.get('/focus-areas', (req, res) => {
+  res.json({ success: true, focusAreas: FOCUS_AREAS });
+});
+
+// GET /api/therapists/consultations/mine — my consultation requests.
+// Defined before /:id so "consultations" isn't captured as an id.
+router.get('/consultations/mine', authenticateToken, async (req, res) => {
+  try {
+    // Include consultations I requested, ones my partner requested (same
+    // couple), AND ones booked with me if I'm a therapist. `role` tells the UI
+    // which side of the conversation the current user is on.
+    const result = await db.query(`
+      SELECT
+        tc.id, tc.focus_area, tc.message, tc.preferred_time, tc.status,
+        tc.responded_at, tc.response_note, tc.created_at,
+        t.display_name AS therapist_name, t.title AS therapist_title,
+        t.user_id AS therapist_user_id,
+        requester.nickname AS requester_name,
+        (SELECT COUNT(*) FROM consultation_messages cm WHERE cm.consultation_id = tc.id) AS message_count
+      FROM therapist_consultations tc
+      JOIN therapists t ON t.id = tc.therapist_id
+      JOIN users requester ON requester.id = tc.requester_id
+      LEFT JOIN couples c ON c.id = tc.couple_id
+      WHERE tc.requester_id = $1
+         OR c.user1_id = $1
+         OR c.user2_id = $1
+         OR t.user_id = $1
+      ORDER BY tc.created_at DESC
+    `, [req.user.id]);
+    res.json({
+      success: true,
+      consultations: result.rows.map((r) => ({
+        id: r.id,
+        therapistName: r.therapist_name,
+        therapistTitle: r.therapist_title,
+        requesterName: r.requester_name,
+        role: r.therapist_user_id && r.therapist_user_id === req.user.id ? 'therapist' : 'client',
+        focusArea: r.focus_area,
+        message: r.message,
+        preferredTime: r.preferred_time,
+        status: r.status,
+        respondedAt: r.responded_at,
+        responseNote: r.response_note,
+        messageCount: Number(r.message_count) || 0,
+        createdAt: r.created_at,
+      })),
+    });
+  } catch (error) {
+    logError('Failed to list my consultations', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法取得預約紀錄' });
+  }
+});
+
+// GET /api/therapists/consultations/:id/messages — the group-chat log for a
+// consultation room. Participants only.
+router.get('/consultations/:id/messages', authenticateToken, async (req, res) => {
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個諮商室' });
+    if (!access.isParticipant) return res.status(403).json({ success: false, message: '你沒有權限進入這個諮商室' });
+
+    const msgs = await db.query(`
+      SELECT cm.id, cm.sender_id, cm.body, cm.event_id, cm.created_at,
+             u.nickname AS sender_name,
+             e.title AS event_title, e.summary AS event_summary
+      FROM consultation_messages cm
+      JOIN users u ON u.id = cm.sender_id
+      LEFT JOIN events e ON e.id = cm.event_id
+      WHERE cm.consultation_id = $1
+      ORDER BY cm.created_at ASC
+    `, [req.params.id]);
+
+    const therapistUserId = access.row.therapist_user_id;
+    res.json({
+      success: true,
+      role: access.role,
+      therapistName: access.row.therapist_name,
+      currentUserId: req.user.id,
+      messages: msgs.rows.map((m) => ({
+        id: m.id,
+        senderId: m.sender_id,
+        senderName: m.sender_name,
+        body: m.body,
+        createdAt: m.created_at,
+        isTherapist: Boolean(therapistUserId) && m.sender_id === therapistUserId,
+        isMine: m.sender_id === req.user.id,
+        event: m.event_id ? { id: m.event_id, title: m.event_title, summary: m.event_summary } : null,
+      })),
+    });
+  } catch (error) {
+    logError('Failed to load consultation messages', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法載入訊息' });
+  }
+});
+
+// POST /api/therapists/consultations/:id/messages — post a chat message,
+// optionally anchored to one of the couple's recorded events.
+router.post('/consultations/:id/messages', authenticateToken, [
+  body('body').isString().trim().isLength({ min: 1, max: 2000 }).withMessage('訊息長度需為 1-2000 字'),
+  body('eventId').optional({ nullable: true }).isUUID().withMessage('eventId 無效'),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個諮商室' });
+    if (!access.isParticipant) return res.status(403).json({ success: false, message: '你沒有權限在這個諮商室發言' });
+
+    let eventId = req.body.eventId || null;
+    if (eventId) {
+      // Only let a message reference an event that belongs to this room's couple.
+      const ev = await db.query(
+        `SELECT id FROM events WHERE id = $1 AND couple_id = $2`,
+        [eventId, access.row.couple_id]
+      );
+      if (ev.rows.length === 0) {
+        return res.status(400).json({ success: false, message: '引用的事件無效' });
+      }
+    }
+
+    const ins = await db.query(
+      `INSERT INTO consultation_messages (consultation_id, sender_id, body, event_id)
+       VALUES ($1, $2, $3, $4) RETURNING id, created_at`,
+      [req.params.id, req.user.id, req.body.body.trim(), eventId]
+    );
+    logInfo('Consultation message posted', { consultationId: req.params.id, userId: req.user.id });
+    res.status(201).json({
+      success: true,
+      message: { id: ins.rows[0].id, createdAt: ins.rows[0].created_at },
+    });
+  } catch (error) {
+    logError('Failed to post consultation message', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '送出訊息失敗' });
+  }
+});
+
+// POST /api/therapists/consultations/:id/respond — the therapist accepts /
+// declines / completes a consultation. Therapist (linked user) only.
+router.post('/consultations/:id/respond', authenticateToken, [
+  body('action').isIn(['accept', 'decline', 'complete']).withMessage('action 無效'),
+  body('note').optional({ nullable: true }).isString().isLength({ max: 1000 }),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個預約' });
+    if (!access.isTherapist) return res.status(403).json({ success: false, message: '只有諮商師可以回覆預約' });
+
+    const statusMap = { accept: 'accepted', decline: 'declined', complete: 'completed' };
+    const status = statusMap[req.body.action];
+    const result = await db.query(
+      `UPDATE therapist_consultations
+          SET status = $1, response_note = $2, responded_at = NOW()
+        WHERE id = $3 RETURNING id, status`,
+      [status, req.body.note || null, req.params.id]
+    );
+    res.json({ success: true, consultation: result.rows[0] });
+  } catch (error) {
+    logError('Failed to respond to consultation', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '回覆預約失敗' });
+  }
+});
+
+// GET /api/therapists/applications/mine — application status for the logged-in
+// user (so an applicant can see "審核中 / 已通過 / 未通過").
+router.get('/applications/mine', authenticateToken, async (req, res) => {
+  try {
+    const result = await db.query(
+      `SELECT id, display_name, status, review_note, created_at, reviewed_at
+         FROM therapists WHERE user_id = $1 ORDER BY created_at DESC`,
+      [req.user.id]
+    );
+    res.json({
+      success: true,
+      applications: result.rows.map((r) => ({
+        id: r.id,
+        displayName: r.display_name,
+        status: r.status,
+        reviewNote: r.review_note,
+        createdAt: r.created_at,
+        reviewedAt: r.reviewed_at,
+      })),
+    });
+  } catch (error) {
+    logError('Failed to list my applications', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法取得申請紀錄' });
+  }
+});
+
+// GET /api/therapists/:id — single approved therapist.
+router.get('/:id', optionalAuth, async (req, res) => {
+  try {
+    const result = await db.query(
+      `SELECT * FROM therapists WHERE id = $1 AND status = 'approved'`,
+      [req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ success: false, message: '找不到這位諮商師' });
+    }
+    res.json({ success: true, therapist: toPublicTherapist(result.rows[0]) });
+  } catch (error) {
+    logError('Failed to fetch therapist', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法取得諮商師資料' });
+  }
+});
+
+// --- Apply to become a therapist ----------------------------------------
+
+// POST /api/therapists/apply
+// optionalAuth: a logged-in user gets linked via user_id, but anyone can apply.
+router.post('/apply', optionalAuth, [
+  body('displayName').isString().trim().isLength({ min: 1, max: 120 }).withMessage('請填寫姓名'),
+  body('title').optional({ nullable: true }).isString().isLength({ max: 120 }),
+  body('licenseNo').optional({ nullable: true }).isString().isLength({ max: 80 }),
+  body('focusAreas').isArray({ min: 1 }).withMessage('請至少選擇一個專長領域'),
+  body('languages').optional().isArray(),
+  body('yearsExperience').optional({ nullable: true }).isInt({ min: 0, max: 80 }).withMessage('年資無效'),
+  body('bio').optional({ nullable: true }).isString().isLength({ max: 2000 }),
+  body('photoUrl').optional({ nullable: true }).isString().isLength({ max: 1000 }),
+  body('rateTwd').isInt({ min: 0, max: 100000 }).withMessage('費率無效'),
+  body('sessionMinutes').optional().isInt({ min: 10, max: 240 }).withMessage('時長無效'),
+  body('contactEmail').isEmail().withMessage('請填寫有效的聯絡 Email'),
+  body('contactPhone').optional({ nullable: true }).isString().isLength({ max: 40 }),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const {
+      displayName, title, licenseNo, languages, yearsExperience,
+      bio, photoUrl, rateTwd, sessionMinutes, contactEmail, contactPhone,
+    } = req.body;
+
+    const focusAreas = sanitizeStringArray(req.body.focusAreas, FOCUS_AREAS);
+    if (focusAreas.length === 0) {
+      return res.status(400).json({ success: false, message: '請至少選擇一個有效的專長領域' });
+    }
+    const langs = sanitizeStringArray(languages);
+
+    const userId = req.user ? req.user.id : null;
+
+    const result = await db.query(`
+      INSERT INTO therapists
+        (user_id, display_name, title, license_no, focus_areas, languages,
+         years_experience, bio, photo_url, rate_twd, session_minutes,
+         contact_email, contact_phone, status)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,'pending')
+      RETURNING id, status, created_at
+    `, [
+      userId, displayName.trim(), title || null, licenseNo || null, focusAreas, langs,
+      yearsExperience ?? null, bio || null, photoUrl || null, rateTwd,
+      sessionMinutes ?? 50, contactEmail.trim(), contactPhone || null,
+    ]);
+
+    logInfo('Therapist application submitted', { userId, therapistId: result.rows[0].id });
+    res.status(201).json({
+      success: true,
+      message: '申請已送出，我們會在審核後與你聯繫',
+      application: {
+        id: result.rows[0].id,
+        status: result.rows[0].status,
+        createdAt: result.rows[0].created_at,
+      },
+    });
+  } catch (error) {
+    logError('Failed to submit therapist application', { err: error.message });
+    res.status(500).json({ success: false, message: '送出申請失敗，請稍後再試' });
+  }
+});
+
+// --- Request a consultation ---------------------------------------------
+
+// POST /api/therapists/:id/consult — logged-in user books a chat with a
+// therapist. Records couple_id when the requester is paired.
+router.post('/:id/consult', authenticateToken, [
+  body('focusArea').optional({ nullable: true }).isIn(FOCUS_AREAS).withMessage('focusArea 無效'),
+  body('message').optional({ nullable: true }).isString().isLength({ max: 2000 }),
+  body('contactEmail').optional({ nullable: true }).isEmail().withMessage('Email 格式錯誤'),
+  body('preferredTime').optional({ nullable: true }).isISO8601().withMessage('時間格式錯誤'),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const therapistId = req.params.id;
+    const userId = req.user.id;
+
+    const therapist = await db.query(
+      `SELECT id FROM therapists WHERE id = $1 AND status = 'approved'`,
+      [therapistId]
+    );
+    if (therapist.rows.length === 0) {
+      return res.status(404).json({ success: false, message: '找不到這位諮商師' });
+    }
+
+    // Record the couple if the requester is paired (either side of the couple).
+    const couple = await db.query(
+      `SELECT id FROM couples WHERE user1_id = $1 OR user2_id = $1 LIMIT 1`,
+      [userId]
+    );
+    const coupleId = couple.rows[0] ? couple.rows[0].id : null;
+
+    const { focusArea, message, contactEmail, preferredTime } = req.body;
+
+    const result = await db.query(`
+      INSERT INTO therapist_consultations
+        (therapist_id, requester_id, couple_id, focus_area, message,
+         contact_email, preferred_time)
+      VALUES ($1,$2,$3,$4,$5,$6,$7)
+      RETURNING id, status, created_at
+    `, [
+      therapistId, userId, coupleId, focusArea || null, message || null,
+      contactEmail || req.user.email || null, preferredTime || null,
+    ]);
+
+    logInfo('Consultation requested', { userId, therapistId, consultationId: result.rows[0].id });
+    res.status(201).json({
+      success: true,
+      message: '預約已送出，諮商師將盡快與你聯繫',
+      consultation: {
+        id: result.rows[0].id,
+        status: result.rows[0].status,
+        createdAt: result.rows[0].created_at,
+      },
+    });
+  } catch (error) {
+    logError('Failed to request consultation', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '預約失敗，請稍後再試' });
+  }
+});
+
+// --- Admin moderation (Basic-Auth gated in server.js) -------------------
+
+// GET /api/admin/therapists?status=pending — review queue.
+adminRouter.get('/', async (req, res) => {
+  try {
+    const status = ['pending', 'approved', 'rejected'].includes(req.query.status)
+      ? req.query.status : 'pending';
+    const result = await db.query(
+      `SELECT * FROM therapists WHERE status = $1 ORDER BY created_at DESC`,
+      [status]
+    );
+    res.json({ success: true, therapists: result.rows });
+  } catch (error) {
+    logError('Admin: failed to list therapists', { err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to list therapists' });
+  }
+});
+
+// POST /api/admin/therapists/:id/review { action: 'approve'|'reject', note }
+adminRouter.post('/:id/review', express.json(), async (req, res) => {
+  try {
+    const action = req.body && req.body.action;
+    if (!['approve', 'reject'].includes(action)) {
+      return res.status(400).json({ success: false, message: "action must be 'approve' or 'reject'" });
+    }
+    const status = action === 'approve' ? 'approved' : 'rejected';
+    const result = await db.query(
+      `UPDATE therapists
+          SET status = $1, review_note = $2, reviewed_at = NOW(), updated_at = NOW()
+        WHERE id = $3
+        RETURNING id, status`,
+      [status, (req.body && req.body.note) || null, req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ success: false, message: 'Therapist not found' });
+    }
+    logInfo('Admin reviewed therapist', { id: req.params.id, status });
+    res.json({ success: true, therapist: result.rows[0] });
+  } catch (error) {
+    logError('Admin: failed to review therapist', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to review therapist' });
+  }
+});
+
+module.exports = { router, adminRouter, FOCUS_AREAS };

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ const eventRoutes = require('./routes/events');
 const scriptFavoritesRoutes = require('./routes/script-favorites');
 const marketplaceRoutes = require('./routes/marketplace');
 const billingRoutes = require('./routes/billing');
+const therapistRoutes = require('./routes/therapists');
 const adminRoutes = require('./routes/admin');
 
 // Import database and middleware
@@ -145,6 +146,13 @@ app.use('/api/billing', billingRoutes);
 // Additional mount for intimacy endpoints (frontend compatibility)
 app.use('/api/intimacy', intimacyRequestRoutes);
 
+// Human therapist directory. The public router handles browse + apply
+// (optionalAuth inside) and JWT-protected consultation booking. Admin
+// moderation (approve/reject applications) is Basic-Auth gated like the rest
+// of /api/admin/*.
+app.use('/api/therapists', therapistRoutes.router);
+app.use('/api/admin/therapists', adminAuth, therapistRoutes.adminRouter);
+
 // Admin funnel dashboard. The public router (POST /api/track/landing) is the
 // anonymous beacon fired from the frontend on the logged-out landing render.
 // The /api/admin/* JSON endpoints and the /admin HTML page are gated by
@@ -162,6 +170,15 @@ app.get('/admin', adminAuth, adminRoutes.htmlHandler);
 app.get(['/pricing', '/membership', '/plans'], (req, res) => {
   res.setHeader('Cache-Control', 'no-cache');
   res.sendFile(path.join(__dirname, 'public', 'pricing.html'));
+});
+
+// Public, no-login therapist recruitment / sign-up page. The SPA gates most
+// views behind auth, so this explicit route (registered before the static
+// catch-all) serves a self-contained static form that POSTs to the public
+// /api/therapists/apply endpoint. Anyone can apply without an account.
+app.get(['/therapist-signup', '/become-a-therapist'], (req, res) => {
+  res.setHeader('Cache-Control', 'no-cache');
+  res.sendFile(path.join(__dirname, 'public', 'therapist-signup.html'));
 });
 
 // Serve static files from the frontend build

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import UpgradeView, { BillingResultView } from './components/UpgradeView';
 import RoleplayView from './components/RoleplayView';
 import WallView from './components/WallView';
 import EventsView from './components/EventsView';
+import TherapistsView from './components/TherapistsView';
 import type { WallExample } from './components/WallPostComposer';
 import { AchievementsView, IntimacyStatsCards, CalendarHeatmap } from './components/AchievementsView';
 import Header from './components/Header';
@@ -5534,6 +5535,9 @@ const LoveTimeApp = () => {
           customEmotions={customEmotions}
           setCustomEmotions={setCustomEmotions}
         />;
+        // Therapist directory is browseable (and applicable) while logged out;
+        // booking a consultation prompts for login inside the modal.
+        case 'therapists': return <TherapistsView authState={authState} showNotification={showNotification} />;
         default: return (
           <div className="flex items-center justify-center min-h-[60vh]">
             <div className="text-center max-w-md">
@@ -5627,6 +5631,7 @@ const LoveTimeApp = () => {
         />
       );
       case 'upgrade': return <UpgradeView reason={upgradeReason} showNotification={showNotification} />;
+      case 'therapists': return <TherapistsView authState={authState} showNotification={showNotification} />;
       default: return <GamesView />;
     }
   };
@@ -5782,6 +5787,7 @@ const LoveTimeApp = () => {
         onShowSettings={() => setCurrentView('settings')}
         onShowJourney={() => setCurrentView('journey')}
         onShowIntimacyHistory={() => setCurrentView('intimacy-history')}
+        onShowTherapists={() => setCurrentView('therapists')}
         onShowUpgrade={() => { setUpgradeReason(null); setCurrentView('upgrade'); }}
       />
       

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { User, LogOut, Coins, Heart, Bell, Send, Settings, Trophy, Inbox, Crown } from 'lucide-react';
+import { User, LogOut, Coins, Heart, Bell, Send, Settings, Trophy, Inbox, Crown, HeartHandshake } from 'lucide-react';
 import { apiService } from '../services/api';
 
 interface User {
@@ -28,6 +28,7 @@ interface HeaderProps {
   onShowSettings: () => void;
   onShowJourney: () => void;
   onShowIntimacyHistory: () => void;
+  onShowTherapists: () => void;
   onShowUpgrade: () => void;
 }
 
@@ -42,6 +43,7 @@ const Header: React.FC<HeaderProps> = ({
   onShowSettings,
   onShowJourney,
   onShowIntimacyHistory,
+  onShowTherapists,
   onShowUpgrade,
 }) => {
   const [showUserMenu, setShowUserMenu] = useState(false);
@@ -194,6 +196,17 @@ const Header: React.FC<HeaderProps> = ({
                       >
                         <Inbox className="w-3.5 h-3.5" strokeWidth={1.5} />
                         <span>訊息紀錄</span>
+                      </button>
+                      <button
+                        onClick={() => {
+                          onShowTherapists();
+                          setShowUserMenu(false);
+                        }}
+                        data-testid="user-menu-therapists"
+                        className="w-full flex items-center space-x-2 px-3 py-2 font-body text-sm text-petal-ink-soft hover:bg-petal-cream-2 rounded-md transition-colors"
+                      >
+                        <HeartHandshake className="w-3.5 h-3.5" strokeWidth={1.5} />
+                        <span>心理諮商</span>
                       </button>
                       <button
                         onClick={() => {

--- a/src/components/TherapistsView.tsx
+++ b/src/components/TherapistsView.tsx
@@ -1,0 +1,740 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Heart, Sparkles, X, UserPlus, Clock, Languages, Award, CalendarCheck, MessageCircle, Send, StickyNote } from 'lucide-react';
+import {
+  apiService,
+  type Therapist,
+  type TherapistFocusArea,
+  type TherapistConsultation,
+  type ConsultationThread,
+  type EventRecord,
+} from '../services/api';
+import type { Notification } from './ErrorNotification';
+import { useScrollLock } from '../hooks/useScrollLock';
+
+interface TherapistsViewProps {
+  authState: {
+    user: { id: string; nickname?: string } | null;
+    isAuthenticated: boolean;
+    partnerConnected: boolean;
+  };
+  showNotification: (notification: Omit<Notification, 'id'>) => void;
+}
+
+// Focus areas — keep the value/label/emoji in one place so the filter chips,
+// cards, and forms all read from the same source of truth. Order matches the
+// backend FOCUS_AREAS list in routes/therapists.js.
+const FOCUS_AREAS: { id: TherapistFocusArea; label: string; emoji: string }[] = [
+  { id: 'couple', label: '伴侶關係', emoji: '💞' },
+  { id: 'family', label: '家庭', emoji: '🏡' },
+  { id: 'childhood', label: '童年/原生家庭', emoji: '🧸' },
+  { id: 'individual', label: '個人成長', emoji: '🌱' },
+  { id: 'sexuality', label: '性與親密', emoji: '🔥' },
+  { id: 'parenting', label: '親職教養', emoji: '👶' },
+  { id: 'grief', label: '悲傷失落', emoji: '🕊️' },
+  { id: 'anxiety', label: '焦慮憂鬱', emoji: '🌧️' },
+];
+
+const focusLabel = (id: string): string =>
+  FOCUS_AREAS.find((f) => f.id === id)?.label || id;
+
+const LANGUAGE_LABEL: Record<string, string> = {
+  zh: '中文',
+  en: 'English',
+  ja: '日本語',
+  ko: '한국어',
+};
+const languageLabel = (code: string): string => LANGUAGE_LABEL[code] || code;
+
+const formatNtd = (n: number): string => `NT$${n.toLocaleString('en-US')}`;
+
+const CONSULTATION_STATUS: Record<TherapistConsultation['status'], { label: string; cls: string }> = {
+  pending: { label: '等待回覆', cls: 'text-petal-rose-deep' },
+  accepted: { label: '已接受', cls: 'text-petal-sage-deep' },
+  declined: { label: '已婉拒', cls: 'text-petal-muted' },
+  completed: { label: '已完成', cls: 'text-petal-sage-deep' },
+  cancelled: { label: '已取消', cls: 'text-petal-muted' },
+};
+
+const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotification }) => {
+  const [therapists, setTherapists] = useState<Therapist[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [focusFilter, setFocusFilter] = useState<TherapistFocusArea | 'all'>('all');
+
+  const [bookingTarget, setBookingTarget] = useState<Therapist | null>(null);
+  const [showMine, setShowMine] = useState(false);
+  const [chatTarget, setChatTarget] = useState<TherapistConsultation | null>(null);
+  const [consultations, setConsultations] = useState<TherapistConsultation[]>([]);
+  const [consultationsLoaded, setConsultationsLoaded] = useState(false);
+
+  const loadTherapists = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await apiService.getTherapists(
+        focusFilter === 'all' ? undefined : focusFilter
+      );
+      setTherapists(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '無法取得諮商師列表');
+    } finally {
+      setLoading(false);
+    }
+  }, [focusFilter]);
+
+  useEffect(() => {
+    loadTherapists();
+  }, [loadTherapists]);
+
+  const loadConsultations = useCallback(async () => {
+    if (!authState.isAuthenticated) return;
+    try {
+      const data = await apiService.getMyConsultations();
+      setConsultations(data);
+      setConsultationsLoaded(true);
+    } catch (err) {
+      console.error('Failed to load consultations:', err);
+    }
+  }, [authState.isAuthenticated]);
+
+  const openMine = () => {
+    setShowMine(true);
+    if (!consultationsLoaded) loadConsultations();
+  };
+
+  const pendingCount = useMemo(
+    () => consultations.filter((c) => c.status === 'pending').length,
+    [consultations]
+  );
+
+  return (
+    <div className="space-y-8" data-testid="therapists-view">
+      {/* Intro */}
+      <div className="text-center max-w-2xl mx-auto">
+        <div className="font-body text-[11px] font-medium uppercase tracking-[0.18em] text-petal-muted mb-3">
+          — 心理諮商
+        </div>
+        <h2 className="font-display text-3xl md:text-4xl font-light tracking-tight text-petal-ink leading-[1.1] mb-3">
+          與真人 <em className="not-italic italic text-pink-600">諮商心理師</em> 聊聊
+        </h2>
+        <p className="font-display italic font-light text-base text-petal-muted">
+          有些議題值得和一位受過專業訓練的人好好談。選擇一位諮商師，預約屬於你們的對話。
+        </p>
+
+        {/* AI rephrase remains the cheaper, always-on option */}
+        <div className="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-full border border-petal-rule bg-petal-cream-2">
+          <Sparkles className="w-3.5 h-3.5 text-pink-500" strokeWidth={1.5} />
+          <span className="font-body text-xs text-petal-ink-soft">
+            只是想換個溫柔的說法？<span className="text-petal-ink">AI 潤稿</span> 仍隨時為你服務，且更省。
+          </span>
+        </div>
+      </div>
+
+      {/* Actions row */}
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {/* Sign-up is a public, no-login page (served by the backend at
+            /therapist-signup) so therapists can apply without an account. */}
+        <a
+          href="/therapist-signup"
+          data-testid="therapist-apply-button"
+          className="flex items-center gap-1.5 px-4 py-2 rounded-full bg-petal-ink text-petal-cream hover:bg-pink-700 transition-colors font-body text-[13px] font-medium"
+        >
+          <UserPlus className="w-3.5 h-3.5" strokeWidth={1.5} />
+          成為諮商師
+        </a>
+        {authState.isAuthenticated && (
+          <button
+            onClick={openMine}
+            data-testid="therapist-mybookings-button"
+            className="flex items-center gap-1.5 px-4 py-2 rounded-full border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors font-body text-[13px] font-medium"
+          >
+            <CalendarCheck className="w-3.5 h-3.5" strokeWidth={1.5} />
+            我的預約{pendingCount > 0 ? ` (${pendingCount})` : ''}
+          </button>
+        )}
+      </div>
+
+      {/* Focus filter */}
+      <div className="flex flex-wrap justify-center gap-1.5">
+        <FilterChip
+          active={focusFilter === 'all'}
+          onClick={() => setFocusFilter('all')}
+          label="全部"
+          emoji="✨"
+        />
+        {FOCUS_AREAS.map((f) => (
+          <FilterChip
+            key={f.id}
+            active={focusFilter === f.id}
+            onClick={() => setFocusFilter(f.id)}
+            label={f.label}
+            emoji={f.emoji}
+          />
+        ))}
+      </div>
+
+      {/* List */}
+      {loading ? (
+        <p className="text-center font-body text-sm text-petal-muted py-12">載入中…</p>
+      ) : error ? (
+        <div className="text-center py-12">
+          <p className="font-body text-sm text-petal-rose-deep mb-3">{error}</p>
+          <button
+            onClick={loadTherapists}
+            className="font-body text-sm text-petal-ink underline underline-offset-4"
+          >
+            重新載入
+          </button>
+        </div>
+      ) : therapists.length === 0 ? (
+        <p className="text-center font-body text-sm text-petal-muted py-12">
+          這個領域目前還沒有諮商師，換個領域看看吧。
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {therapists.map((t) => (
+            <TherapistCard key={t.id} therapist={t} onBook={() => setBookingTarget(t)} />
+          ))}
+        </div>
+      )}
+
+      {bookingTarget && (
+        <ConsultationModal
+          therapist={bookingTarget}
+          defaultEmail={authState.user ? undefined : undefined}
+          isAuthenticated={authState.isAuthenticated}
+          onClose={() => setBookingTarget(null)}
+          onBooked={() => {
+            setBookingTarget(null);
+            setConsultationsLoaded(false);
+            showNotification({
+              type: 'success',
+              title: '預約已送出',
+              message: '諮商師將盡快與你聯繫',
+              duration: 3500,
+            });
+          }}
+          showNotification={showNotification}
+        />
+      )}
+
+      {showMine && (
+        <MyConsultationsModal
+          consultations={consultations}
+          onClose={() => setShowMine(false)}
+          onOpenRoom={(c) => setChatTarget(c)}
+        />
+      )}
+
+      {chatTarget && (
+        <ChatRoom
+          consultation={chatTarget}
+          onClose={() => { setChatTarget(null); setConsultationsLoaded(false); loadConsultations(); }}
+          showNotification={showNotification}
+        />
+      )}
+    </div>
+  );
+};
+
+// --- Filter chip ----------------------------------------------------------
+
+const FilterChip: React.FC<{ active: boolean; onClick: () => void; label: string; emoji: string }> = ({
+  active, onClick, label, emoji,
+}) => (
+  <button
+    onClick={onClick}
+    className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-full transition-colors border font-body text-[13px] font-medium tracking-tight ${
+      active
+        ? 'bg-petal-ink text-petal-cream border-petal-ink'
+        : 'bg-transparent text-petal-ink-soft border-petal-rule hover:border-petal-ink hover:text-petal-ink'
+    }`}
+  >
+    <span>{emoji}</span>
+    <span>{label}</span>
+  </button>
+);
+
+// --- Therapist card -------------------------------------------------------
+
+const TherapistCard: React.FC<{ therapist: Therapist; onBook: () => void }> = ({ therapist, onBook }) => (
+  <div
+    className="flex flex-col bg-petal-cream rounded-lg border border-petal-rule shadow-petal overflow-hidden"
+    data-testid="therapist-card"
+  >
+    <div className="flex gap-4 p-5">
+      {/* Avatar — contained, never cropped (project image rule) */}
+      <div className="w-20 h-20 shrink-0 rounded-full overflow-hidden bg-petal-cream-2 border border-petal-rule flex items-center justify-center">
+        {therapist.photoUrl ? (
+          <img
+            src={therapist.photoUrl}
+            alt={therapist.displayName}
+            className="w-full h-full object-contain"
+          />
+        ) : (
+          <Heart className="w-8 h-8 text-pink-300" strokeWidth={1.5} />
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <h3 className="font-display text-xl font-medium text-petal-ink">{therapist.displayName}</h3>
+          {therapist.title && (
+            <span className="font-body text-xs text-petal-muted">{therapist.title}</span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 font-body text-xs text-petal-ink-soft">
+          {typeof therapist.yearsExperience === 'number' && (
+            <span className="inline-flex items-center gap-1">
+              <Award className="w-3 h-3" strokeWidth={1.5} /> {therapist.yearsExperience} 年資歷
+            </span>
+          )}
+          {therapist.languages.length > 0 && (
+            <span className="inline-flex items-center gap-1">
+              <Languages className="w-3 h-3" strokeWidth={1.5} />
+              {therapist.languages.map(languageLabel).join('・')}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5 mt-2.5">
+          {therapist.focusAreas.map((a) => (
+            <span
+              key={a}
+              className="px-2 py-0.5 rounded-full bg-petal-cream-2 border border-petal-rule font-body text-[11px] text-petal-ink-soft"
+            >
+              {focusLabel(a)}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+
+    {therapist.bio && (
+      <p className="px-5 font-body text-sm text-petal-ink-soft leading-relaxed line-clamp-4">
+        {therapist.bio}
+      </p>
+    )}
+
+    <div className="mt-auto flex items-center justify-between gap-3 px-5 py-4 mt-4 border-t border-petal-rule">
+      <div className="font-body text-sm text-petal-ink">
+        <span className="font-display text-lg text-pink-600">{formatNtd(therapist.rateTwd)}</span>
+        <span className="text-petal-muted text-xs"> / {therapist.sessionMinutes} 分鐘</span>
+      </div>
+      <button
+        onClick={onBook}
+        data-testid="therapist-book-button"
+        className="px-4 py-2 rounded-full bg-pink-500 text-white hover:bg-pink-600 transition-colors font-body text-[13px] font-medium"
+      >
+        預約諮詢
+      </button>
+    </div>
+  </div>
+);
+
+// --- Modal shell ----------------------------------------------------------
+
+const ModalShell: React.FC<{ title: string; onClose: () => void; children: React.ReactNode }> = ({
+  title, onClose, children,
+}) => {
+  useScrollLock(true);
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-0 sm:p-4">
+      <div className="bg-petal-cream w-full sm:max-w-lg max-h-[92vh] overflow-y-auto rounded-t-2xl sm:rounded-lg border border-petal-rule shadow-petal">
+        <div className="sticky top-0 bg-petal-cream flex items-center justify-between px-5 py-4 border-b border-petal-rule">
+          <h3 className="font-display text-xl font-medium text-petal-ink">{title}</h3>
+          <button onClick={onClose} className="p-1 text-petal-muted hover:text-petal-ink" aria-label="關閉">
+            <X className="w-5 h-5" strokeWidth={1.5} />
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+const fieldLabel = 'block font-body text-xs font-medium text-petal-ink-soft mb-1.5';
+const fieldInput =
+  'w-full px-3 py-2 rounded-md border border-petal-rule bg-petal-cream focus:border-petal-ink focus:outline-none font-body text-sm text-petal-ink';
+
+// --- Consultation modal ---------------------------------------------------
+
+const ConsultationModal: React.FC<{
+  therapist: Therapist;
+  defaultEmail?: string;
+  isAuthenticated: boolean;
+  onClose: () => void;
+  onBooked: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ therapist, isAuthenticated, onClose, onBooked, showNotification }) => {
+  const [focusArea, setFocusArea] = useState<TherapistFocusArea | ''>(
+    therapist.focusAreas[0] || ''
+  );
+  const [message, setMessage] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [preferredTime, setPreferredTime] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (!isAuthenticated) {
+      showNotification({ type: 'warning', title: '請先登入', message: '登入後即可預約諮詢', duration: 3000 });
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await apiService.requestConsultation(therapist.id, {
+        focusArea: focusArea || undefined,
+        message: message.trim() || undefined,
+        contactEmail: contactEmail.trim() || undefined,
+        preferredTime: preferredTime ? new Date(preferredTime).toISOString() : undefined,
+      });
+      onBooked();
+    } catch (err) {
+      showNotification({
+        type: 'error',
+        title: '預約失敗',
+        message: err instanceof Error ? err.message : '請稍後再試',
+        duration: 4000,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalShell title={`預約 ${therapist.displayName}`} onClose={onClose}>
+      <div className="space-y-4" data-testid="consultation-modal">
+        <p className="font-body text-sm text-petal-muted">
+          {formatNtd(therapist.rateTwd)} / {therapist.sessionMinutes} 分鐘 · 送出後諮商師會與你聯繫安排時間。
+        </p>
+
+        <div>
+          <label className={fieldLabel}>想談的主題</label>
+          <select
+            value={focusArea}
+            onChange={(e) => setFocusArea(e.target.value as TherapistFocusArea)}
+            className={fieldInput}
+          >
+            <option value="">不指定</option>
+            {therapist.focusAreas.map((a) => (
+              <option key={a} value={a}>{focusLabel(a)}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className={fieldLabel}>想聊聊的事（選填）</label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={4}
+            maxLength={2000}
+            placeholder="簡單描述你們目前的狀況或想處理的議題…"
+            className={`${fieldInput} resize-none`}
+            data-testid="consultation-message"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className={fieldLabel}>聯絡 Email（選填）</label>
+            <input
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              placeholder="預設使用帳號 Email"
+              className={fieldInput}
+            />
+          </div>
+          <div>
+            <label className={fieldLabel}>希望的時段（選填）</label>
+            <input
+              type="datetime-local"
+              value={preferredTime}
+              onChange={(e) => setPreferredTime(e.target.value)}
+              className={fieldInput}
+            />
+          </div>
+        </div>
+
+        <button
+          onClick={submit}
+          disabled={submitting}
+          data-testid="consultation-submit"
+          className="w-full py-2.5 rounded-md bg-petal-ink text-petal-cream hover:bg-pink-700 disabled:opacity-50 transition-colors font-body text-sm font-medium"
+        >
+          {submitting ? '送出中…' : '送出預約'}
+        </button>
+      </div>
+    </ModalShell>
+  );
+};
+
+// --- My consultations modal ----------------------------------------------
+
+const MyConsultationsModal: React.FC<{
+  consultations: TherapistConsultation[];
+  onClose: () => void;
+  onOpenRoom: (c: TherapistConsultation) => void;
+}> = ({ consultations, onClose, onOpenRoom }) => (
+  <ModalShell title="我的預約" onClose={onClose}>
+    {consultations.length === 0 ? (
+      <p className="font-body text-sm text-petal-muted py-6 text-center">
+        還沒有預約紀錄。挑一位諮商師開始吧。
+      </p>
+    ) : (
+      <div className="space-y-3" data-testid="my-consultations">
+        {consultations.map((c) => {
+          const status = CONSULTATION_STATUS[c.status];
+          return (
+            <div key={c.id} className="rounded-md border border-petal-rule p-4" data-testid="consultation-row">
+              <div className="flex items-center justify-between gap-2">
+                <div className="font-display text-base text-petal-ink">
+                  {c.therapistName}
+                  {c.therapistTitle && (
+                    <span className="font-body text-xs text-petal-muted ml-2">{c.therapistTitle}</span>
+                  )}
+                  {c.role === 'therapist' && (
+                    <span className="ml-2 px-1.5 py-0.5 rounded bg-petal-cream-2 border border-petal-rule font-body text-[10px] text-petal-ink-soft">
+                      你是諮商師 · 來自 {c.requesterName}
+                    </span>
+                  )}
+                </div>
+                <span className={`font-body text-xs font-medium ${status.cls}`}>{status.label}</span>
+              </div>
+              {c.focusArea && (
+                <div className="mt-1 font-body text-xs text-petal-ink-soft">
+                  主題：{focusLabel(c.focusArea)}
+                </div>
+              )}
+              {c.message && (
+                <p className="mt-1.5 font-body text-sm text-petal-ink-soft line-clamp-3">{c.message}</p>
+              )}
+              {c.preferredTime && (
+                <div className="mt-1.5 inline-flex items-center gap-1 font-body text-xs text-petal-muted">
+                  <Clock className="w-3 h-3" strokeWidth={1.5} />
+                  希望時段：{new Date(c.preferredTime).toLocaleString('zh-TW')}
+                </div>
+              )}
+              {c.responseNote && (
+                <p className="mt-2 font-body text-sm text-petal-sage-deep">
+                  諮商師回覆：{c.responseNote}
+                </p>
+              )}
+              <button
+                onClick={() => onOpenRoom(c)}
+                data-testid="enter-room-button"
+                className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-petal-ink text-petal-cream hover:bg-pink-700 transition-colors font-body text-xs font-medium"
+              >
+                <MessageCircle className="w-3.5 h-3.5" strokeWidth={1.5} />
+                進入諮商室{c.messageCount > 0 ? ` (${c.messageCount})` : ''}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    )}
+  </ModalShell>
+);
+
+// --- Consultation chat room ----------------------------------------------
+
+// Group chat for a consultation: both partners + the therapist. Polls for new
+// messages every few seconds while open. Couple members can anchor a message
+// to one of their recorded events via the event picker.
+const ChatRoom: React.FC<{
+  consultation: TherapistConsultation;
+  onClose: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ consultation, onClose, showNotification }) => {
+  const [thread, setThread] = useState<ConsultationThread | null>(null);
+  const [draft, setDraft] = useState('');
+  const [events, setEvents] = useState<EventRecord[]>([]);
+  const [selectedEvent, setSelectedEvent] = useState<EventRecord | null>(null);
+  const [showEventPicker, setShowEventPicker] = useState(false);
+  const [sending, setSending] = useState(false);
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const t = await apiService.getConsultationMessages(consultation.id);
+      setThread(t);
+    } catch (err) {
+      console.error('Failed to load thread:', err);
+    }
+  }, [consultation.id]);
+
+  useEffect(() => {
+    load();
+    const timer = setInterval(load, 4000); // lightweight polling, MVP
+    return () => clearInterval(timer);
+  }, [load]);
+
+  // The event picker only makes sense for couple members (their own events).
+  useEffect(() => {
+    if (consultation.role === 'client') {
+      apiService.listEvents({ limit: 50 })
+        .then((r) => setEvents(r.events))
+        .catch(() => { /* non-fatal */ });
+    }
+  }, [consultation.role]);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [thread?.messages.length]);
+
+  const send = async () => {
+    const body = draft.trim();
+    if (!body) return;
+    try {
+      setSending(true);
+      await apiService.postConsultationMessage(consultation.id, body, selectedEvent?.id);
+      setDraft('');
+      setSelectedEvent(null);
+      await load();
+    } catch (err) {
+      showNotification({
+        type: 'error',
+        title: '送出失敗',
+        message: err instanceof Error ? err.message : '請稍後再試',
+        duration: 3500,
+      });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  useScrollLock(true);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-0 sm:p-4">
+      <div className="bg-petal-cream w-full sm:max-w-lg h-[92vh] sm:h-[80vh] flex flex-col rounded-t-2xl sm:rounded-lg border border-petal-rule shadow-petal" data-testid="chat-room">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-petal-rule">
+          <div>
+            <h3 className="font-display text-lg font-medium text-petal-ink">諮商室 · {consultation.therapistName}</h3>
+            <p className="font-body text-xs text-petal-muted">
+              你們與諮商師的對話 — 可引用記錄過的「事件」一起討論
+            </p>
+          </div>
+          <button onClick={onClose} className="p-1 text-petal-muted hover:text-petal-ink" aria-label="關閉">
+            <X className="w-5 h-5" strokeWidth={1.5} />
+          </button>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3" data-testid="chat-messages">
+          {!thread ? (
+            <p className="text-center font-body text-sm text-petal-muted">載入中…</p>
+          ) : thread.messages.length === 0 ? (
+            <p className="text-center font-body text-sm text-petal-muted py-8">
+              還沒有訊息。打個招呼，開始你們的對話吧。
+            </p>
+          ) : (
+            thread.messages.map((m) => (
+              <div key={m.id} className={`flex ${m.isMine ? 'justify-end' : 'justify-start'}`}>
+                <div className={`max-w-[80%] ${m.isMine ? 'items-end' : 'items-start'} flex flex-col`}>
+                  <div className="font-body text-[11px] text-petal-muted mb-0.5 px-1">
+                    {m.isTherapist ? `🩺 ${m.senderName}（諮商師）` : m.senderName}
+                  </div>
+                  {m.event && (
+                    <div className="mb-1 px-3 py-2 rounded-lg bg-petal-cream-2 border border-petal-rule max-w-full">
+                      <div className="font-body text-[10px] uppercase tracking-wide text-petal-muted">引用事件</div>
+                      <div className="font-body text-xs font-medium text-petal-ink">{m.event.title}</div>
+                      <div className="font-body text-xs text-petal-ink-soft line-clamp-2">{m.event.summary}</div>
+                    </div>
+                  )}
+                  <div
+                    className={`px-3.5 py-2 rounded-2xl font-body text-sm ${
+                      m.isMine
+                        ? 'bg-petal-ink text-petal-cream rounded-br-sm'
+                        : m.isTherapist
+                          ? 'bg-pink-100 text-petal-ink rounded-bl-sm'
+                          : 'bg-petal-cream-2 text-petal-ink rounded-bl-sm'
+                    }`}
+                  >
+                    {m.body}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+          <div ref={endRef} />
+        </div>
+
+        {/* Composer */}
+        <div className="border-t border-petal-rule px-4 py-3">
+          {selectedEvent && (
+            <div className="mb-2 flex items-center gap-2 px-3 py-1.5 rounded-lg bg-petal-cream-2 border border-petal-rule">
+              <span className="font-body text-xs text-petal-ink-soft truncate">引用：{selectedEvent.title}</span>
+              <button onClick={() => setSelectedEvent(null)} className="ml-auto text-petal-muted hover:text-petal-ink">
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            {consultation.role === 'client' && (
+              <button
+                onClick={() => setShowEventPicker(true)}
+                data-testid="reference-event-button"
+                title="引用事件"
+                className="shrink-0 p-2 rounded-full border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors"
+              >
+                <StickyNote className="w-4 h-4" strokeWidth={1.5} />
+              </button>
+            )}
+            <input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } }}
+              placeholder="輸入訊息…"
+              data-testid="chat-input"
+              className="flex-1 px-3.5 py-2 rounded-full border border-petal-rule bg-petal-cream focus:border-petal-ink focus:outline-none font-body text-sm text-petal-ink"
+            />
+            <button
+              onClick={send}
+              disabled={sending || !draft.trim()}
+              data-testid="chat-send"
+              className="shrink-0 p-2.5 rounded-full bg-pink-500 text-white hover:bg-pink-600 disabled:opacity-40 transition-colors"
+            >
+              <Send className="w-4 h-4" strokeWidth={1.5} />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Event picker overlay */}
+      {showEventPicker && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" onClick={() => setShowEventPicker(false)}>
+          <div className="bg-petal-cream w-full max-w-md max-h-[70vh] overflow-y-auto rounded-lg border border-petal-rule shadow-petal" onClick={(e) => e.stopPropagation()}>
+            <div className="sticky top-0 bg-petal-cream flex items-center justify-between px-4 py-3 border-b border-petal-rule">
+              <h4 className="font-display text-base text-petal-ink">引用一個事件</h4>
+              <button onClick={() => setShowEventPicker(false)} className="text-petal-muted hover:text-petal-ink"><X className="w-4 h-4" /></button>
+            </div>
+            <div className="p-3 space-y-2" data-testid="event-picker">
+              {events.length === 0 ? (
+                <p className="font-body text-sm text-petal-muted text-center py-6">
+                  你們還沒有記錄過事件。
+                </p>
+              ) : (
+                events.map((ev) => (
+                  <button
+                    key={ev.id}
+                    onClick={() => { setSelectedEvent(ev); setShowEventPicker(false); }}
+                    className="w-full text-left px-3 py-2.5 rounded-md border border-petal-rule hover:border-petal-ink transition-colors"
+                  >
+                    <div className="font-body text-sm font-medium text-petal-ink">{ev.title}</div>
+                    <div className="font-body text-xs text-petal-ink-soft line-clamp-2">{ev.summary}</div>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TherapistsView;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -672,6 +672,81 @@ apiClient.interceptors.response.use(
   }
 );
 
+// Human therapist (心理諮商師) directory types
+export type TherapistFocusArea =
+  | 'family' | 'couple' | 'childhood' | 'individual'
+  | 'sexuality' | 'parenting' | 'grief' | 'anxiety';
+
+export interface Therapist {
+  id: string;
+  displayName: string;
+  title?: string | null;
+  focusAreas: TherapistFocusArea[];
+  languages: string[];
+  yearsExperience?: number | null;
+  bio?: string | null;
+  photoUrl?: string | null;
+  rateTwd: number;
+  sessionMinutes: number;
+  createdAt: string;
+}
+
+export interface TherapistApplicationInput {
+  displayName: string;
+  title?: string;
+  licenseNo?: string;
+  focusAreas: TherapistFocusArea[];
+  languages?: string[];
+  yearsExperience?: number | null;
+  bio?: string;
+  photoUrl?: string;
+  rateTwd: number;
+  sessionMinutes?: number;
+  contactEmail: string;
+  contactPhone?: string;
+}
+
+export interface ConsultationRequestInput {
+  focusArea?: TherapistFocusArea;
+  message?: string;
+  contactEmail?: string;
+  preferredTime?: string;
+}
+
+export interface TherapistConsultation {
+  id: string;
+  therapistName: string;
+  therapistTitle?: string | null;
+  requesterName?: string | null;
+  role: 'therapist' | 'client';
+  focusArea?: TherapistFocusArea | null;
+  message?: string | null;
+  preferredTime?: string | null;
+  status: 'pending' | 'accepted' | 'declined' | 'completed' | 'cancelled';
+  respondedAt?: string | null;
+  responseNote?: string | null;
+  messageCount: number;
+  createdAt: string;
+}
+
+export interface ConsultationMessage {
+  id: string;
+  senderId: string;
+  senderName: string;
+  body: string;
+  createdAt: string;
+  isTherapist: boolean;
+  isMine: boolean;
+  event: { id: string; title: string; summary: string } | null;
+}
+
+export interface ConsultationThread {
+  role: 'therapist' | 'client';
+  therapistName: string;
+  currentUserId: string;
+  messages: ConsultationMessage[];
+}
+
 // API Service Class
 class ApiService {
   private throwApiError(error: unknown, fallbackMessage: string): never {
@@ -2292,6 +2367,88 @@ class ApiService {
     } catch (error: unknown) {
       console.error('Failed to start checkout:', error);
       this.throwApiError(error, '無法建立付款，請稍後再試');
+    }
+  }
+
+  // --- Human therapists (心理諮商師) ---
+
+  async getTherapists(focus?: TherapistFocusArea): Promise<Therapist[]> {
+    try {
+      const response = await apiClient.get('/therapists', {
+        params: focus ? { focus } : undefined,
+      });
+      return (response.data?.therapists || []) as Therapist[];
+    } catch (error: unknown) {
+      console.error('Failed to fetch therapists:', error);
+      this.throwApiError(error, '無法取得諮商師列表');
+    }
+  }
+
+  async getTherapist(id: string): Promise<Therapist> {
+    try {
+      const response = await apiClient.get(`/therapists/${id}`);
+      return response.data?.therapist as Therapist;
+    } catch (error: unknown) {
+      console.error('Failed to fetch therapist:', error);
+      this.throwApiError(error, '無法取得諮商師資料');
+    }
+  }
+
+  async applyAsTherapist(input: TherapistApplicationInput): Promise<{ id: string; status: string }> {
+    try {
+      const response = await apiClient.post('/therapists/apply', input);
+      return response.data?.application;
+    } catch (error: unknown) {
+      console.error('Failed to submit therapist application:', error);
+      this.throwApiError(error, '送出申請失敗，請稍後再試');
+    }
+  }
+
+  async requestConsultation(therapistId: string, input: ConsultationRequestInput): Promise<{ id: string; status: string }> {
+    try {
+      const response = await apiClient.post(`/therapists/${therapistId}/consult`, input);
+      return response.data?.consultation;
+    } catch (error: unknown) {
+      console.error('Failed to request consultation:', error);
+      this.throwApiError(error, '預約失敗，請稍後再試');
+    }
+  }
+
+  async getMyConsultations(): Promise<TherapistConsultation[]> {
+    try {
+      const response = await apiClient.get('/therapists/consultations/mine');
+      return (response.data?.consultations || []) as TherapistConsultation[];
+    } catch (error: unknown) {
+      console.error('Failed to fetch consultations:', error);
+      this.throwApiError(error, '無法取得預約紀錄');
+    }
+  }
+
+  async getConsultationMessages(consultationId: string): Promise<ConsultationThread> {
+    try {
+      const response = await apiClient.get(`/therapists/consultations/${consultationId}/messages`);
+      const d = response.data || {};
+      return {
+        role: d.role,
+        therapistName: d.therapistName,
+        currentUserId: d.currentUserId,
+        messages: (d.messages || []) as ConsultationMessage[],
+      };
+    } catch (error: unknown) {
+      console.error('Failed to fetch consultation messages:', error);
+      this.throwApiError(error, '無法載入訊息');
+    }
+  }
+
+  async postConsultationMessage(consultationId: string, body: string, eventId?: string): Promise<void> {
+    try {
+      await apiClient.post(`/therapists/consultations/${consultationId}/messages`, {
+        body,
+        eventId: eventId || undefined,
+      });
+    } catch (error: unknown) {
+      console.error('Failed to post consultation message:', error);
+      this.throwApiError(error, '送出訊息失敗');
     }
   }
 }

--- a/tests/therapist-flow.spec.ts
+++ b/tests/therapist-flow.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Key-flow E2E for the 心理諮商師 (human therapist) feature. Chrome-only, MVP
+// scope: the public sign-up page, browsing therapists, booking a consultation,
+// and exchanging a message in the consultation chat room.
+//
+// Locator policy: getByTestId for click targets, text only for content
+// assertions (matches the rest of the suite).
+
+const TEST_USER = {
+  email: 'test-e2e@twogether.app',
+  password: 'test123456',
+};
+
+// The public sign-up page is served by the Express backend (not Vite), so we
+// hit it directly on :8080 rather than through the SPA dev server on :5174.
+const BACKEND_BASE = process.env.PLAYWRIGHT_BACKEND_BASE || 'http://localhost:8080';
+
+async function login(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('pairingPromptDismissed', 'true');
+  });
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+
+  const loginButton = page.getByTestId('header-auth-button');
+  const userMenu = page.getByTestId('user-menu-toggle');
+
+  await Promise.race([
+    loginButton.waitFor({ state: 'visible', timeout: 20000 }),
+    userMenu.waitFor({ state: 'visible', timeout: 20000 }),
+  ]).catch(() => {});
+
+  if (await userMenu.isVisible({ timeout: 2000 }).catch(() => false)) {
+    return; // already authenticated (session reused)
+  }
+
+  await loginButton.click();
+  await expect(page.getByTestId('auth-modal-heading')).toBeVisible({ timeout: 5000 });
+  await page.getByTestId('auth-email-input').fill(TEST_USER.email);
+  await page.getByTestId('auth-password-input').fill(TEST_USER.password);
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/auth/login'), { timeout: 15000 }),
+    page.getByTestId('auth-submit-button').click(),
+  ]);
+  await userMenu.waitFor({ state: 'visible', timeout: 20000 });
+}
+
+async function openTherapists(page: Page) {
+  await page.getByTestId('user-menu-toggle').click();
+  await page.getByTestId('user-menu-therapists').click();
+  await expect(page.getByTestId('therapists-view')).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Therapist counseling', () => {
+  test('public sign-up page accepts an application', async ({ page }) => {
+    await page.goto(`${BACKEND_BASE}/therapist-signup`);
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.fill('input[name="displayName"]', 'E2E 測試諮商師');
+    await page.fill('input[name="contactEmail"]', `e2e-therapist-${Date.now()}@example.com`);
+    // Pick a focus area (clicking the label toggles its checkbox).
+    await page.click('#focus label:has(input[value="anxiety"])');
+
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/therapists/apply'), { timeout: 15000 }),
+      page.click('#submit'),
+    ]);
+
+    await expect(page.locator('#result.ok')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#result')).toContainText('申請已送出');
+  });
+
+  test('browse, book, and chat in a consultation room', async ({ page }) => {
+    await login(page);
+    await openTherapists(page);
+
+    // Browse: the seeded therapists should render as cards.
+    const firstCard = page.getByTestId('therapist-card').first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+
+    // Book a consultation with the first therapist.
+    await firstCard.getByTestId('therapist-book-button').click();
+    await expect(page.getByTestId('consultation-modal')).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('consultation-message').fill('E2E 想預約諮詢');
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/consult') && r.request().method() === 'POST', { timeout: 15000 }),
+      page.getByTestId('consultation-submit').click(),
+    ]);
+
+    // Open "我的預約" and enter the consultation room.
+    await page.getByTestId('therapist-mybookings-button').click();
+    await expect(page.getByTestId('my-consultations')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('enter-room-button').first().click();
+    await expect(page.getByTestId('chat-room')).toBeVisible({ timeout: 10000 });
+
+    // Send a message and confirm it shows up in the thread.
+    const msg = `E2E 訊息 ${Date.now()}`;
+    await page.getByTestId('chat-input').fill(msg);
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/messages') && r.request().method() === 'POST', { timeout: 15000 }),
+      page.getByTestId('chat-send').click(),
+    ]);
+    await expect(page.getByTestId('chat-messages')).toContainText(msg, { timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a "talk to a real, certified 心理諮商師" path alongside the existing (cheaper) AI rephrase flow.

- **Browse & book** approved therapists (focus area, rate, languages, bio). Entry point is the Header user menu (心理諮商).
- **Public, no-login sign-up page** at `/therapist-signup` so therapists can apply without an account; applications land as `pending`.
- **Admin approval tab** (諮商師) in the `/admin` dashboard to approve/reject applications.
- **Group chat room** per consultation: both partners + the therapist talk, and a message can be anchored to one of the couple's recorded **events**. Polling-based, participant-scoped access control.

> Note: based on `feat/premium-passes-ecpay` (stacked on that PR), so the diff here is only the therapist feature.

## Changes
**Backend**
- Migrations `041_therapists` (therapists + consultations, seeded) and `042_consultation_chat` (consultation_messages).
- `routes/therapists.js`: public/JWT router (browse, apply, consult, chat) + Basic-Auth admin router (list/approve/reject), mounted in `server.js`.
- Public `/therapist-signup` route; 諮商師 admin tab in `routes/admin.js`.

**Frontend**
- `TherapistsView` (browse, book, my-bookings, chat room with event-reference picker), `api.ts` types + methods, Header + App wiring.

**Access control**
- Chat participants = the requester, anyone in the consultation's couple (both partners), or the therapist's linked user account. Outsiders get 403.

## Testing
- New `tests/therapist-flow.spec.ts` (Chrome): public signup; browse → book → enter room → send message.
- 17-assertion backend e2e covering the full chat flow (event references, role detection, outsider 403, therapist accept) + admin approve → appears in browse — all pass.
- `tsc -b` clean, build clean, new code lints clean.
- **Full Playwright suite: 23/23 green** (2 new + 21 existing, no regressions).

## Follow-up (not blocking)
Therapists chat through their linked user account (`therapists.user_id`, set when applying while logged in). The seeded sample therapists have no account, so they're browse-only until a real logged-in applicant signs up or one is linked. Couple-side chat works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)