### PR TITLE
Therapist accounts: self-service profiles, email verification, identity docs, admin moderation

### DIFF
--- a/database/migrations/044_therapist_accounts.sql
+++ b/database/migrations/044_therapist_accounts.sql
@@ -1,0 +1,68 @@
+-- Therapist accounts, self-service profiles, email verification, identity docs,
+-- custom expertise areas, and the "suspended" moderation state.
+--
+-- Background: migration 041 created the therapists directory where applicants
+-- submit a public form and admins approve/reject. This migration grows that
+-- into a real account-backed flow:
+--
+--   1. Every approved/applying therapist is linked to a `users` row (user_id
+--      already exists from 041) so they can log in and edit their own profile
+--      (name, rate, photo, bio, …). Sign-up now provisions that account.
+--   2. Email verification — therapists confirm the contact email is theirs via
+--      a tokenised link before their profile is trusted.
+--   3. Identity documents — therapists upload certificates / licences for the
+--      admin to verify their credentials. Stored as an array of file URLs.
+--   4. Custom expertise areas — free-text specialties beyond the fixed
+--      focus_areas list, so therapists aren't boxed into our 8 categories.
+--   5. A `suspended` status so admins can temporarily hide an approved
+--      therapist (e.g. while investigating a complaint) without deleting them.
+
+ALTER TABLE therapists
+  -- Free-text expertise the therapist typed in themselves (e.g. "EMDR",
+  -- "創傷知情", "LGBTQ+ 友善"). Complements the fixed focus_areas taxonomy.
+  ADD COLUMN IF NOT EXISTS custom_specialties TEXT[] NOT NULL DEFAULT '{}',
+
+  -- Email verification. verified flips true when the therapist clicks the
+  -- tokenised link we email them. token is cleared once used.
+  ADD COLUMN IF NOT EXISTS email_verified BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS email_verification_token TEXT,
+  ADD COLUMN IF NOT EXISTS email_verification_sent_at TIMESTAMP WITH TIME ZONE,
+
+  -- Identity / credential documents uploaded for admin review. Array of file
+  -- URLs (certificates, licences). Shown to admins only — never in the public
+  -- browse payload.
+  ADD COLUMN IF NOT EXISTS identity_documents TEXT[] NOT NULL DEFAULT '{}',
+
+  -- Identity review state, tracked separately from the listing `status` so a
+  -- therapist can be live (approved) while their documents are still pending,
+  -- or flagged for missing credentials.
+  --   unverified : no documents submitted yet
+  --   submitted  : documents uploaded, awaiting admin review
+  --   verified   : admin confirmed credentials
+  --   rejected   : admin rejected the submitted documents
+  ADD COLUMN IF NOT EXISTS identity_status VARCHAR(16) NOT NULL DEFAULT 'unverified';
+
+-- Widen the listing status to allow 'suspended'. The constraint from 041 only
+-- permitted pending/approved/rejected, so drop and recreate it.
+ALTER TABLE therapists DROP CONSTRAINT IF EXISTS therapists_status_valid;
+ALTER TABLE therapists ADD CONSTRAINT therapists_status_valid
+  CHECK (status IN ('pending', 'approved', 'rejected', 'suspended'));
+
+ALTER TABLE therapists DROP CONSTRAINT IF EXISTS therapists_identity_status_valid;
+ALTER TABLE therapists ADD CONSTRAINT therapists_identity_status_valid
+  CHECK (identity_status IN ('unverified', 'submitted', 'verified', 'rejected'));
+
+-- A user account maps to (in practice) one therapist profile. Non-unique
+-- partial index: we enforce "one active profile per user" in the apply handler
+-- rather than via a DB constraint, so this migration can never fail on legacy
+-- data that already has two rows for the same user. GET /api/therapists/me
+-- still resolves deterministically by ordering newest-first.
+CREATE INDEX IF NOT EXISTS idx_therapists_by_user
+  ON therapists(user_id, created_at DESC)
+  WHERE user_id IS NOT NULL;
+
+-- Looking a therapist up by their email-verification token must be fast and
+-- only matches the (at most one) row mid-verification.
+CREATE INDEX IF NOT EXISTS idx_therapists_email_token
+  ON therapists(email_verification_token)
+  WHERE email_verification_token IS NOT NULL;

--- a/public/therapist-signup.html
+++ b/public/therapist-signup.html
@@ -75,6 +75,21 @@
     <div class="card">
       <div id="result" class="result"></div>
       <form id="form">
+        <div class="field" style="text-align:center;">
+          <label>大頭照</label>
+          <div style="display:flex; align-items:center; gap:16px; justify-content:center;">
+            <div id="photoSlot" style="width:96px; height:96px; border-radius:50%; overflow:hidden; background:var(--cream-2); border:1px solid var(--rule); display:flex; align-items:center; justify-content:center; flex-shrink:0;">
+              <img id="photoPreview" alt="" style="width:100%; height:100%; object-fit:contain; display:none;" />
+              <span id="photoPlaceholder" style="font-size:32px; color:var(--muted);">🙂</span>
+            </div>
+            <div style="text-align:left;">
+              <input type="file" id="photoFile" accept="image/png,image/jpeg,image/webp" style="display:none;" />
+              <button type="button" id="photoBtn" class="submit" style="width:auto; margin:0; padding:9px 16px;">上傳照片</button>
+              <p class="note" id="photoStatus" style="text-align:left; margin:8px 0 0;">JPG / PNG / WebP，5MB 以內。</p>
+            </div>
+          </div>
+        </div>
+
         <div class="row">
           <div class="field">
             <label>姓名 <span class="req">*</span></label>
@@ -102,7 +117,23 @@
             <label class="chip"><input type="checkbox" value="parenting" />👶 親職教養</label>
             <label class="chip"><input type="checkbox" value="grief" />🕊️ 悲傷失落</label>
             <label class="chip"><input type="checkbox" value="anxiety" />🌧️ 焦慮憂鬱</label>
+            <label class="chip"><input type="checkbox" value="depression" />🌫️ 憂鬱情緒</label>
+            <label class="chip"><input type="checkbox" value="trauma" />💔 創傷</label>
+            <label class="chip"><input type="checkbox" value="addiction" />🎯 成癮</label>
+            <label class="chip"><input type="checkbox" value="lgbtq" />🏳️‍🌈 性別與多元認同</label>
+            <label class="chip"><input type="checkbox" value="career" />💼 職涯/工作壓力</label>
+            <label class="chip"><input type="checkbox" value="self_esteem" />✨ 自我價值</label>
           </div>
+        </div>
+
+        <div class="field">
+          <label>自訂專長 / 取向（選填，最多 8 個）</label>
+          <div class="chips" id="customTags"></div>
+          <div style="display:flex; gap:8px; margin-top:8px;">
+            <input type="text" id="customInput" maxlength="40" placeholder="例如：EMDR、創傷知情、CBT…" />
+            <button type="button" id="customAdd" class="submit" style="width:auto; margin:0; padding:10px 18px;">新增</button>
+          </div>
+          <p class="note" style="text-align:left; margin-top:8px;">找不到合適的分類？在這裡加上你自己的取向或專長。</p>
         </div>
 
         <div class="field">
@@ -139,11 +170,20 @@
           <div class="field">
             <label>聯絡 Email <span class="req">*</span></label>
             <input type="email" name="contactEmail" maxlength="255" required />
+            <p class="note" style="text-align:left; margin-top:6px;">我們會寄一封驗證信到這個信箱。送出後也會用這個 Email 幫你建立登入帳號。</p>
           </div>
           <div class="field">
             <label>聯絡電話</label>
             <input type="tel" name="contactPhone" maxlength="40" />
           </div>
+        </div>
+
+        <div class="field">
+          <label>證照 / 身分證明文件（選填，建議上傳以加速審核）</label>
+          <div id="docList" style="margin-bottom:8px;"></div>
+          <input type="file" id="docFile" accept="image/png,image/jpeg,image/webp,application/pdf" style="display:none;" />
+          <button type="button" id="docBtn" class="submit" style="width:auto; margin:0; padding:9px 16px;">上傳文件</button>
+          <p class="note" id="docStatus" style="text-align:left; margin:8px 0 0;">諮商師證照、執業執照等。JPG / PNG / WebP / PDF，10MB 以內。文件僅供審核，不會公開。</p>
         </div>
 
         <button type="submit" class="submit" id="submit">送出申請</button>
@@ -155,9 +195,16 @@
   </div>
 
   <script>
+    function esc(s) {
+      return String(s == null ? '' : s).replace(/[<>&"]/g, function (c) {
+        return { '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' }[c];
+      });
+    }
+
     // Toggle chip visual state when its checkbox changes.
     document.querySelectorAll('.chip').forEach(function (chip) {
       var cb = chip.querySelector('input');
+      if (!cb) return;
       var sync = function () { chip.classList.toggle('on', cb.checked); };
       cb.addEventListener('change', sync);
       sync();
@@ -173,12 +220,121 @@
     var result = document.getElementById('result');
     var submit = document.getElementById('submit');
 
-    function show(kind, msg) {
+    function show(kind, html) {
       result.className = 'result ' + kind;
-      result.textContent = msg;
+      result.innerHTML = html;
       result.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
 
+    // ── Profile photo upload ────────────────────────────────────────────────
+    var photoUrl = '';
+    var photoBtn = document.getElementById('photoBtn');
+    var photoFile = document.getElementById('photoFile');
+    var photoStatus = document.getElementById('photoStatus');
+    var photoPreview = document.getElementById('photoPreview');
+    var photoPlaceholder = document.getElementById('photoPlaceholder');
+
+    photoBtn.addEventListener('click', function () { photoFile.click(); });
+    photoFile.addEventListener('change', function () {
+      var file = photoFile.files && photoFile.files[0];
+      if (!file) return;
+      photoBtn.disabled = true;
+      photoStatus.textContent = '上傳中…';
+      var fd = new FormData();
+      fd.append('photo', file);
+      fetch('/api/therapists/upload-photo', { method: 'POST', body: fd })
+        .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, b: b }; }); })
+        .then(function (res) {
+          if (res.ok && res.b.success && res.b.url) {
+            photoUrl = res.b.url;
+            photoPreview.src = photoUrl;
+            photoPreview.style.display = 'block';
+            photoPlaceholder.style.display = 'none';
+            photoStatus.textContent = '✓ 照片已上傳';
+          } else {
+            photoStatus.textContent = (res.b && res.b.message) || '上傳失敗，請換一張或稍後再試';
+          }
+        })
+        .catch(function () { photoStatus.textContent = '網路錯誤，請稍後再試'; })
+        .finally(function () { photoBtn.disabled = false; });
+    });
+
+    // ── Custom specialty tags ───────────────────────────────────────────────
+    var customTags = [];
+    var customWrap = document.getElementById('customTags');
+    var customInput = document.getElementById('customInput');
+    var customAdd = document.getElementById('customAdd');
+
+    function renderTags() {
+      customWrap.innerHTML = customTags.map(function (t, i) {
+        return '<span class="chip on" data-i="' + i + '" style="cursor:default;">' +
+          esc(t) + ' <span data-remove="' + i + '" style="cursor:pointer; margin-left:4px;">✕</span></span>';
+      }).join('');
+      customWrap.querySelectorAll('[data-remove]').forEach(function (el) {
+        el.addEventListener('click', function () {
+          customTags.splice(Number(el.getAttribute('data-remove')), 1);
+          renderTags();
+        });
+      });
+    }
+    function addTag() {
+      var v = (customInput.value || '').trim().slice(0, 40);
+      if (!v) return;
+      if (customTags.length >= 8) { customInput.value = ''; return; }
+      if (customTags.indexOf(v) === -1) customTags.push(v);
+      customInput.value = '';
+      renderTags();
+    }
+    customAdd.addEventListener('click', addTag);
+    customInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); addTag(); }
+    });
+
+    // ── Credential documents upload ─────────────────────────────────────────
+    var docUrls = [];
+    var docBtn = document.getElementById('docBtn');
+    var docFile = document.getElementById('docFile');
+    var docStatus = document.getElementById('docStatus');
+    var docList = document.getElementById('docList');
+
+    function renderDocs() {
+      docList.innerHTML = docUrls.map(function (u, i) {
+        return '<div style="display:flex; align-items:center; gap:8px; font-size:13px; margin-bottom:4px;">' +
+          '<span>📎 文件 ' + (i + 1) + '</span>' +
+          '<a href="' + esc(u) + '" target="_blank" rel="noopener" style="color:var(--rose);">檢視</a>' +
+          '<span data-rmdoc="' + i + '" style="cursor:pointer; color:var(--muted);">移除</span></div>';
+      }).join('');
+      docList.querySelectorAll('[data-rmdoc]').forEach(function (el) {
+        el.addEventListener('click', function () {
+          docUrls.splice(Number(el.getAttribute('data-rmdoc')), 1);
+          renderDocs();
+        });
+      });
+    }
+    docBtn.addEventListener('click', function () { docFile.click(); });
+    docFile.addEventListener('change', function () {
+      var file = docFile.files && docFile.files[0];
+      if (!file) return;
+      docBtn.disabled = true;
+      docStatus.textContent = '上傳中…';
+      var fd = new FormData();
+      fd.append('document', file);
+      fetch('/api/therapists/upload-document', { method: 'POST', body: fd })
+        .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, b: b }; }); })
+        .then(function (res) {
+          if (res.ok && res.b.success && res.b.url) {
+            docUrls.push(res.b.url);
+            renderDocs();
+            docStatus.textContent = '✓ 文件已上傳';
+          } else {
+            docStatus.textContent = (res.b && res.b.message) || '上傳失敗，請稍後再試';
+          }
+        })
+        .catch(function () { docStatus.textContent = '網路錯誤，請稍後再試'; })
+        .finally(function () { docBtn.disabled = false; docFile.value = ''; });
+    });
+
+    // ── Submit application ──────────────────────────────────────────────────
     form.addEventListener('submit', function (e) {
       e.preventDefault();
       var fd = new FormData(form);
@@ -192,9 +348,12 @@
         title: fd.get('title').trim() || undefined,
         licenseNo: fd.get('licenseNo').trim() || undefined,
         focusAreas: focusAreas,
+        customSpecialties: customTags,
         languages: collect('langs'),
         yearsExperience: fd.get('yearsExperience') ? Number(fd.get('yearsExperience')) : undefined,
         bio: fd.get('bio').trim() || undefined,
+        photoUrl: photoUrl || undefined,
+        identityDocuments: docUrls,
         rateTwd: Number(fd.get('rateTwd')) || 0,
         sessionMinutes: Number(fd.get('sessionMinutes')) || 50,
         contactEmail: fd.get('contactEmail').trim(),
@@ -211,11 +370,33 @@
         .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, b: b }; }); })
         .then(function (res) {
           if (res.ok && res.b.success) {
-            form.reset();
-            document.querySelectorAll('.chip').forEach(function (c) {
-              var cb = c.querySelector('input'); c.classList.toggle('on', cb.checked);
-            });
-            show('ok', '✓ 申請已送出！我們會在審核通過後與你聯繫。');
+            // Build a credentials / next-steps panel so the applicant knows
+            // exactly how to log in and that they must verify their email.
+            var acct = res.b.account || {};
+            var loginBlock;
+            if (acct.created && acct.password) {
+              loginBlock =
+                '<div style="margin-top:12px; padding:12px 14px; background:#fff; border:1px dashed var(--rose); border-radius:8px; text-align:left;">' +
+                '<div style="font-weight:600; margin-bottom:6px;">你的登入帳號已建立 🎉</div>' +
+                '<div style="font-size:14px;">帳號（Email）：<code>' + esc(acct.email) + '</code></div>' +
+                '<div style="font-size:14px;">臨時密碼：<code>' + esc(acct.password) + '</code></div>' +
+                '<div style="font-size:13px; color:var(--muted); margin-top:8px;">請記下這組密碼並盡快登入，登入後即可在「我的諮商師檔案」編輯姓名、費率、照片等所有資料。</div>' +
+                '</div>';
+            } else if (acct.existed) {
+              loginBlock =
+                '<div style="margin-top:12px; font-size:14px; text-align:left;">' +
+                '這個 Email（<code>' + esc(acct.email) + '</code>）已經有 Twogether 帳號，請用你原本的密碼登入，' +
+                '即可在「我的諮商師檔案」編輯資料。</div>';
+            } else {
+              loginBlock =
+                '<div style="margin-top:12px; font-size:14px; text-align:left;">' +
+                '你已登入，可直接在「我的諮商師檔案」編輯資料。</div>';
+            }
+            var verifyBlock =
+              '<div style="margin-top:10px; font-size:13px; color:var(--muted); text-align:left;">' +
+              '📧 我們已寄出一封驗證信到 <code>' + esc(acct.email) + '</code>，請點擊信中的連結完成 Email 驗證。</div>';
+            show('ok', '<div style="font-weight:600;">✓ 申請已送出！我們會在審核通過後與你聯繫。</div>' + loginBlock + verifyBlock);
+            form.style.display = 'none';
           } else {
             show('err', (res.b && res.b.message) || '送出失敗，請稍後再試');
           }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -632,6 +632,7 @@ const ADMIN_HTML = `<!doctype html>
           <select id="therapistStatus">
             <option value="pending">待審核</option>
             <option value="approved">已通過</option>
+            <option value="suspended">已暫停</option>
             <option value="rejected">未通過</option>
           </select>
         </label>
@@ -646,6 +647,7 @@ const ADMIN_HTML = `<!doctype html>
               <th>專長</th>
               <th class="num">費率</th>
               <th>聯絡 / 證照</th>
+              <th>驗證 / 文件</th>
               <th>申請時間</th>
               <th>操作</th>
             </tr>
@@ -850,7 +852,12 @@ const ADMIN_HTML = `<!doctype html>
     var THERAPIST_FOCUS = {
       couple: '伴侶關係', family: '家庭', childhood: '童年/原生家庭',
       individual: '個人成長', sexuality: '性與親密', parenting: '親職教養',
-      grief: '悲傷失落', anxiety: '焦慮憂鬱'
+      grief: '悲傷失落', anxiety: '焦慮憂鬱', depression: '憂鬱情緒',
+      trauma: '創傷', addiction: '成癮', lgbtq: '性別與多元認同',
+      career: '職涯/工作壓力', self_esteem: '自我價值'
+    };
+    var IDENTITY_STATUS = {
+      unverified: '未提交', submitted: '待審核', verified: '已驗證', rejected: '已退回'
     };
     function esc(s) {
       return (s == null ? '' : String(s)).replace(/[<>&]/g, function (c) {
@@ -875,24 +882,57 @@ const ADMIN_HTML = `<!doctype html>
     function renderTherapists(rows, status) {
       var tbody = document.querySelector('#therapistsTable tbody');
       if (rows.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="6" class="muted">沒有資料</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="7" class="muted">沒有資料</td></tr>';
         return;
       }
       tbody.innerHTML = rows.map(function (t) {
         var focus = (t.focus_areas || []).map(function (f) {
           return '<span class="pill">' + esc(THERAPIST_FOCUS[f] || f) + '</span>';
         }).join(' ');
+        var custom = (t.custom_specialties || []).map(function (f) {
+          return '<span class="pill">' + esc(f) + '</span>';
+        }).join(' ');
         var contact = esc(t.contact_email || '—') +
           (t.license_no ? '<div class="muted" style="font-size:11px">證照: ' + esc(t.license_no) + '</div>' : '');
-        var actions = status === 'pending'
-          ? '<button data-act="approve" data-id="' + t.id + '">通過</button> ' +
-            '<button data-act="reject" data-id="' + t.id + '">退回</button>'
-          : '<span class="muted">' + (status === 'approved' ? '已通過' : '已退回') + '</span>';
+
+        // Email verification + uploaded credential documents.
+        var emailBadge = t.email_verified
+          ? '<span class="badge yes">Email 已驗證</span>'
+          : '<span class="badge no">Email 未驗證</span>';
+        var docs = (t.identity_documents || []).map(function (u, i) {
+          return '<a href="' + esc(u) + '" target="_blank" rel="noopener">文件' + (i + 1) + '</a>';
+        }).join(' · ');
+        var idStatus = '<div class="muted" style="font-size:11px;margin-top:3px">身分: ' +
+          esc(IDENTITY_STATUS[t.identity_status] || t.identity_status || '—') + '</div>';
+        var idActions = (t.identity_documents && t.identity_documents.length)
+          ? '<div style="margin-top:4px"><button data-idact="verify" data-id="' + t.id + '">驗證身分</button> ' +
+            '<button data-idact="reject" data-id="' + t.id + '">退回文件</button></div>'
+          : '';
+        var verifyCell = emailBadge + '<div style="font-size:11px;margin-top:3px">' + (docs || '<span class="muted">無文件</span>') + '</div>' + idStatus + idActions;
+
+        // Status-dependent moderation actions. Approved → suspend/delete;
+        // suspended → reactivate/delete; pending → approve/reject; rejected →
+        // approve (give a second chance) / delete.
+        var actions;
+        if (status === 'pending') {
+          actions = '<button data-act="approve" data-id="' + t.id + '">通過</button> ' +
+            '<button data-act="reject" data-id="' + t.id + '">退回</button>';
+        } else if (status === 'approved') {
+          actions = '<button data-act="suspend" data-id="' + t.id + '">暫停</button> ' +
+            '<button data-act="delete" data-id="' + t.id + '" data-name="' + esc(t.display_name) + '">刪除</button>';
+        } else if (status === 'suspended') {
+          actions = '<button data-act="reactivate" data-id="' + t.id + '">恢復上架</button> ' +
+            '<button data-act="delete" data-id="' + t.id + '" data-name="' + esc(t.display_name) + '">刪除</button>';
+        } else { // rejected
+          actions = '<button data-act="approve" data-id="' + t.id + '">通過</button> ' +
+            '<button data-act="delete" data-id="' + t.id + '" data-name="' + esc(t.display_name) + '">刪除</button>';
+        }
         return '<tr>' +
           '<td><div>' + esc(t.display_name) + '</div><div class="muted" style="font-size:11px">' + esc(t.title || '') + '</div></td>' +
-          '<td>' + focus + '</td>' +
+          '<td>' + focus + (custom ? '<div style="margin-top:4px">' + custom + '</div>' : '') + '</td>' +
           '<td class="num">NT$' + (t.rate_twd || 0).toLocaleString() + ' / ' + (t.session_minutes || 50) + '分</td>' +
           '<td>' + contact + '</td>' +
+          '<td>' + verifyCell + '</td>' +
           '<td>' + fmtDate(t.created_at) + '</td>' +
           '<td>' + actions + '</td>' +
           '</tr>';
@@ -900,7 +940,17 @@ const ADMIN_HTML = `<!doctype html>
 
       tbody.querySelectorAll('button[data-act]').forEach(function (btn) {
         btn.addEventListener('click', function () {
-          reviewTherapist(btn.getAttribute('data-id'), btn.getAttribute('data-act'), btn);
+          var act = btn.getAttribute('data-act');
+          if (act === 'delete') {
+            deleteTherapist(btn.getAttribute('data-id'), btn.getAttribute('data-name'), btn);
+          } else {
+            reviewTherapist(btn.getAttribute('data-id'), act, btn);
+          }
+        });
+      });
+      tbody.querySelectorAll('button[data-idact]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          verifyIdentity(btn.getAttribute('data-id'), btn.getAttribute('data-idact'), btn);
         });
       });
     }
@@ -918,6 +968,35 @@ const ADMIN_HTML = `<!doctype html>
       } catch (e) {
         btn.disabled = false;
         $('therapistStatusMsg').textContent = '操作失敗: ' + e.message;
+      }
+    }
+
+    async function verifyIdentity(id, act, btn) {
+      btn.disabled = true;
+      try {
+        var res = await fetch('/api/admin/therapists/' + id + '/verify-identity', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: act })
+        });
+        if (!res.ok) throw new Error('verify ' + res.status);
+        await loadTherapists();
+      } catch (e) {
+        btn.disabled = false;
+        $('therapistStatusMsg').textContent = '操作失敗: ' + e.message;
+      }
+    }
+
+    async function deleteTherapist(id, name, btn) {
+      if (!window.confirm('確定要永久刪除諮商師「' + (name || '') + '」嗎？此動作無法復原。\n（若只是想暫時下架，請改用「暫停」。）')) return;
+      btn.disabled = true;
+      try {
+        var res = await fetch('/api/admin/therapists/' + id, { method: 'DELETE' });
+        if (!res.ok) throw new Error('delete ' + res.status);
+        await loadTherapists();
+      } catch (e) {
+        btn.disabled = false;
+        $('therapistStatusMsg').textContent = '刪除失敗: ' + e.message;
       }
     }
 

--- a/routes/therapists.js
+++ b/routes/therapists.js
@@ -11,9 +11,16 @@
 // (cheaper) AI rephrase feature — the AI flow is untouched.
 
 const express = require('express');
+const crypto = require('crypto');
+const bcrypt = require('bcryptjs');
+const multer = require('multer');
+const sharp = require('sharp');
+const { v4: uuidv4 } = require('uuid');
 const { body, query: queryValidator, validationResult } = require('express-validator');
 const db = require('../database/db');
-const { authenticateToken, optionalAuth } = require('../middleware/auth');
+const { authenticateToken, optionalAuth, generateToken } = require('../middleware/auth');
+const { uploadToSupabase } = require('../lib/supabase-storage');
+const emailService = require('../services/emailService');
 const { logInfo, logWarn, logError } = require('../lib/logger');
 
 const router = express.Router();
@@ -28,7 +35,29 @@ const FOCUS_AREAS = [
   'parenting',   // 親職
   'grief',       // 悲傷失落
   'anxiety',     // 焦慮憂鬱
+  'depression',  // 憂鬱情緒
+  'trauma',      // 創傷
+  'addiction',   // 成癮
+  'lgbtq',       // 性別與多元認同
+  'career',      // 職涯/工作壓力
+  'self_esteem', // 自我價值
 ];
+
+// Free-text custom specialties: how many a therapist may add and how long each
+// can be. Kept small so the browse card stays readable and the column doesn't
+// become a dumping ground.
+const MAX_CUSTOM_SPECIALTIES = 8;
+const MAX_CUSTOM_SPECIALTY_LEN = 40;
+
+// Generate a human-friendly temporary password for an auto-provisioned
+// therapist account: 12 url-safe chars with no ambiguous 0/O/1/l/I.
+const generateTempPassword = () => {
+  const alphabet = 'ABCDEFGHJKMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';
+  const bytes = crypto.randomBytes(12);
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 1) out += alphabet[bytes[i] % alphabet.length];
+  return out;
+};
 
 // Shape the public-facing therapist object. Never leaks license_no /
 // contact_* — those are private to the applicant and admins.
@@ -37,13 +66,30 @@ const toPublicTherapist = (row) => ({
   displayName: row.display_name,
   title: row.title,
   focusAreas: row.focus_areas || [],
+  customSpecialties: row.custom_specialties || [],
   languages: row.languages || [],
   yearsExperience: row.years_experience,
   bio: row.bio,
   photoUrl: row.photo_url,
   rateTwd: row.rate_twd,
   sessionMinutes: row.session_minutes,
+  identityStatus: row.identity_status,
   createdAt: row.created_at,
+});
+
+// The therapist's own (private) view of their profile — includes contact info,
+// verification + identity state, and moderation status so they understand where
+// their application stands.
+const toOwnTherapist = (row) => ({
+  ...toPublicTherapist(row),
+  licenseNo: row.license_no,
+  contactEmail: row.contact_email,
+  contactPhone: row.contact_phone,
+  status: row.status,
+  reviewNote: row.review_note,
+  emailVerified: row.email_verified,
+  identityDocuments: row.identity_documents || [],
+  identityStatus: row.identity_status,
 });
 
 const sanitizeStringArray = (value, allowList) => {
@@ -54,6 +100,58 @@ const sanitizeStringArray = (value, allowList) => {
   const unique = [...new Set(cleaned)];
   return allowList ? unique.filter((v) => allowList.includes(v)) : unique;
 };
+
+// Normalise free-text custom specialties: trim, drop empties, de-dupe, clamp
+// each to MAX_CUSTOM_SPECIALTY_LEN and the list to MAX_CUSTOM_SPECIALTIES.
+const sanitizeCustomSpecialties = (value) => {
+  if (!Array.isArray(value)) return [];
+  const cleaned = value
+    .map((v) => (typeof v === 'string' ? v.trim().slice(0, MAX_CUSTOM_SPECIALTY_LEN) : ''))
+    .filter(Boolean);
+  return [...new Set(cleaned)].slice(0, MAX_CUSTOM_SPECIALTIES);
+};
+
+// In-memory per-IP rate limit for the public (no-login) upload endpoints used
+// by the therapist sign-up form. Sliding 1-minute window. Keeps an anonymous
+// flood from filling storage without needing a dependency.
+const UPLOAD_RL_WINDOW_MS = 60_000;
+const UPLOAD_RL_MAX = 12;
+const uploadHits = new Map(); // ip -> number[]
+const uploadRateLimited = (ip) => {
+  if (!ip) return false;
+  const now = Date.now();
+  const cutoff = now - UPLOAD_RL_WINDOW_MS;
+  const hits = (uploadHits.get(ip) || []).filter((t) => t > cutoff);
+  if (hits.length >= UPLOAD_RL_MAX) {
+    uploadHits.set(ip, hits);
+    return true;
+  }
+  hits.push(now);
+  uploadHits.set(ip, hits);
+  return false;
+};
+
+// multer in-memory storage for therapist photo + document uploads.
+const photoUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024, files: 1 }, // 5MB
+  fileFilter: (req, file, cb) => {
+    if (!file.originalname.match(/\.(jpg|jpeg|png|webp)$/i)) {
+      return cb(new Error('大頭照只接受 jpg、jpeg、png、webp 圖片格式'), false);
+    }
+    cb(null, true);
+  },
+});
+const documentUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024, files: 1 }, // 10MB
+  fileFilter: (req, file, cb) => {
+    if (!file.originalname.match(/\.(jpg|jpeg|png|webp|pdf)$/i)) {
+      return cb(new Error('證明文件只接受 jpg、jpeg、png、webp 或 pdf 格式'), false);
+    }
+    cb(null, true);
+  },
+});
 
 const handleValidation = (req, res) => {
   const errors = validationResult(req);
@@ -115,6 +213,235 @@ router.get('/', optionalAuth, [
 // GET /api/therapists/focus-areas — the canonical list (for filter chips).
 router.get('/focus-areas', (req, res) => {
   res.json({ success: true, focusAreas: FOCUS_AREAS });
+});
+
+// --- Uploads (public, used by the no-login sign-up form) -----------------
+
+// Shared handler: process an uploaded buffer and push it to Supabase storage,
+// returning the public URL. Photos are resized; documents (incl. PDFs) are
+// stored as-is. Filenames are random UUIDs so document URLs aren't guessable.
+const handleUpload = async (req, res, { kind }) => {
+  try {
+    if (uploadRateLimited(req.ip)) {
+      return res.status(429).json({
+        success: false,
+        error_code: 'UPLOAD_RATE_LIMITED',
+        message: '上傳太頻繁了，請稍等一分鐘再試',
+      });
+    }
+    if (!req.file) {
+      return res.status(400).json({
+        success: false,
+        error_code: 'NO_FILE',
+        message: kind === 'photo' ? '請選擇要上傳的大頭照' : '請選擇要上傳的證明文件',
+      });
+    }
+
+    const ext = (req.file.originalname.match(/\.([a-z0-9]+)$/i)?.[1] || '').toLowerCase();
+    let buffer = req.file.buffer;
+    let mimeType = req.file.mimetype;
+    let outExt = ext;
+
+    if (kind === 'photo' && ext !== 'gif') {
+      // Normalise photos to a reasonable size + JPEG to keep storage small.
+      buffer = await sharp(req.file.buffer)
+        .resize(600, 600, { fit: 'inside', withoutEnlargement: true })
+        .jpeg({ quality: 85, progressive: true })
+        .toBuffer();
+      mimeType = 'image/jpeg';
+      outExt = 'jpg';
+    } else if (kind === 'document' && ext === 'pdf') {
+      mimeType = 'application/pdf';
+    }
+
+    const fileName = `therapist-${kind}/${uuidv4()}-${Date.now()}.${outExt}`;
+    const url = await uploadToSupabase(buffer, fileName, mimeType);
+    logInfo('Therapist asset uploaded', { kind, ip: req.ip });
+    return res.status(201).json({ success: true, url });
+  } catch (error) {
+    logError('Therapist upload failed', { kind, err: error.message });
+    return res.status(500).json({
+      success: false,
+      error_code: 'UPLOAD_FAILED',
+      message: error.message || '上傳失敗，請稍後再試',
+    });
+  }
+};
+
+// POST /api/therapists/upload-photo — profile picture (multipart, field "photo").
+router.post('/upload-photo', (req, res) => {
+  photoUpload.single('photo')(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({ success: false, error_code: 'UPLOAD_REJECTED', message: err.message });
+    }
+    handleUpload(req, res, { kind: 'photo' });
+  });
+});
+
+// POST /api/therapists/upload-document — credential/identity doc (field "document").
+router.post('/upload-document', (req, res) => {
+  documentUpload.single('document')(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({ success: false, error_code: 'UPLOAD_REJECTED', message: err.message });
+    }
+    handleUpload(req, res, { kind: 'document' });
+  });
+});
+
+// --- Email verification (public link target) ----------------------------
+
+// GET /api/therapists/verify-email?token=… — clicked from the verification
+// email. Flips email_verified true and shows a small confirmation page.
+router.get('/verify-email', async (req, res) => {
+  const renderPage = (ok, message) => {
+    res.status(ok ? 200 : 400).type('html').send(`<!doctype html><html lang="zh-Hant"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Email 驗證 · Twogether</title>
+<style>body{font-family:-apple-system,BlinkMacSystemFont,"PingFang TC","Noto Sans TC",sans-serif;background:#fbf7f2;color:#2a2422;display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0;padding:24px}
+.card{background:#fff;border:1px solid #e4dccf;border-radius:14px;padding:36px 32px;max-width:420px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.04)}
+.emoji{font-size:44px}h1{font-size:22px;font-weight:500;margin:14px 0 8px}p{color:#8a807c;font-size:15px;line-height:1.6;margin:0 0 20px}
+a{display:inline-block;background:#2a2422;color:#fbf7f2;text-decoration:none;padding:11px 22px;border-radius:8px;font-size:14px}</style>
+</head><body><div class="card"><div class="emoji">${ok ? '✅' : '⚠️'}</div>
+<h1>${ok ? 'Email 已驗證' : '驗證失敗'}</h1><p>${message}</p>
+<a href="/">回到 Twogether</a></div></body></html>`);
+  };
+
+  try {
+    const token = typeof req.query.token === 'string' ? req.query.token : '';
+    if (!token) return renderPage(false, '驗證連結無效，缺少驗證碼。');
+
+    const result = await db.query(
+      `UPDATE therapists
+          SET email_verified = true, email_verification_token = NULL, updated_at = NOW()
+        WHERE email_verification_token = $1
+        RETURNING id, display_name`,
+      [token]
+    );
+    if (result.rows.length === 0) {
+      return renderPage(false, '這個驗證連結已失效或已經使用過了。如果你已驗證過，可以直接登入。');
+    }
+    logInfo('Therapist email verified', { therapistId: result.rows[0].id });
+    return renderPage(true, '謝謝你！你的 Email 已完成驗證。我們會在審核通過後與你聯繫，你也可以登入編輯個人檔案。');
+  } catch (error) {
+    logError('Therapist email verification failed', { err: error.message });
+    return renderPage(false, '驗證時發生錯誤，請稍後再試。');
+  }
+});
+
+// --- Self-service therapist profile (logged-in therapist) ----------------
+
+// Load the therapist profile linked to a user id (newest first), any status.
+const loadOwnTherapist = async (userId) => {
+  const result = await db.query(
+    `SELECT * FROM therapists WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1`,
+    [userId]
+  );
+  return result.rows[0] || null;
+};
+
+// GET /api/therapists/me — the logged-in user's own therapist profile, if any.
+router.get('/me', authenticateToken, async (req, res) => {
+  try {
+    const row = await loadOwnTherapist(req.user.id);
+    if (!row) {
+      return res.status(404).json({ success: false, error_code: 'NO_THERAPIST_PROFILE', message: '你還沒有諮商師檔案' });
+    }
+    res.json({ success: true, therapist: toOwnTherapist(row) });
+  } catch (error) {
+    logError('Failed to load own therapist profile', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法取得諮商師檔案' });
+  }
+});
+
+// PUT /api/therapists/me — the therapist edits their own profile. Editing never
+// changes their moderation status; a suspended/rejected therapist can still fix
+// their details, but the listing only reappears once an admin re-approves.
+router.put('/me', authenticateToken, [
+  body('displayName').optional().isString().trim().isLength({ min: 1, max: 120 }).withMessage('姓名長度需為 1-120 字'),
+  body('title').optional({ nullable: true }).isString().isLength({ max: 120 }),
+  body('focusAreas').optional().isArray({ min: 1 }).withMessage('請至少選擇一個專長領域'),
+  body('customSpecialties').optional().isArray(),
+  body('languages').optional().isArray(),
+  body('yearsExperience').optional({ nullable: true }).isInt({ min: 0, max: 80 }).withMessage('年資無效'),
+  body('bio').optional({ nullable: true }).isString().isLength({ max: 2000 }),
+  body('photoUrl').optional({ nullable: true }).isString().isLength({ max: 1000 }),
+  body('rateTwd').optional().isInt({ min: 0, max: 100000 }).withMessage('費率無效'),
+  body('sessionMinutes').optional().isInt({ min: 10, max: 240 }).withMessage('時長無效'),
+  body('contactPhone').optional({ nullable: true }).isString().isLength({ max: 40 }),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const existing = await loadOwnTherapist(req.user.id);
+    if (!existing) {
+      return res.status(404).json({ success: false, error_code: 'NO_THERAPIST_PROFILE', message: '你還沒有諮商師檔案，請先申請成為諮商師' });
+    }
+
+    // Build a partial update from only the fields that were provided. Each
+    // entry maps a request field to its column + (optional) sanitiser.
+    const updates = [];
+    const params = [];
+    const push = (col, val) => { params.push(val); updates.push(`${col} = $${params.length}`); };
+
+    if (req.body.displayName !== undefined) push('display_name', req.body.displayName.trim());
+    if (req.body.title !== undefined) push('title', req.body.title || null);
+    if (req.body.focusAreas !== undefined) {
+      const focusAreas = sanitizeStringArray(req.body.focusAreas, FOCUS_AREAS);
+      if (focusAreas.length === 0) {
+        return res.status(400).json({ success: false, error_code: 'NO_FOCUS_AREA', message: '請至少選擇一個有效的專長領域' });
+      }
+      push('focus_areas', focusAreas);
+    }
+    if (req.body.customSpecialties !== undefined) push('custom_specialties', sanitizeCustomSpecialties(req.body.customSpecialties));
+    if (req.body.languages !== undefined) push('languages', sanitizeStringArray(req.body.languages));
+    if (req.body.yearsExperience !== undefined) push('years_experience', req.body.yearsExperience ?? null);
+    if (req.body.bio !== undefined) push('bio', req.body.bio || null);
+    if (req.body.photoUrl !== undefined) push('photo_url', req.body.photoUrl || null);
+    if (req.body.rateTwd !== undefined) push('rate_twd', req.body.rateTwd);
+    if (req.body.sessionMinutes !== undefined) push('session_minutes', req.body.sessionMinutes);
+    if (req.body.contactPhone !== undefined) push('contact_phone', req.body.contactPhone || null);
+
+    if (updates.length === 0) {
+      return res.status(400).json({ success: false, error_code: 'NO_CHANGES', message: '沒有要更新的欄位' });
+    }
+
+    params.push(existing.id);
+    const result = await db.query(
+      `UPDATE therapists SET ${updates.join(', ')}, updated_at = NOW()
+        WHERE id = $${params.length} RETURNING *`,
+      params
+    );
+    logInfo('Therapist profile self-updated', { userId: req.user.id, therapistId: existing.id });
+    res.json({ success: true, message: '檔案已更新', therapist: toOwnTherapist(result.rows[0]) });
+  } catch (error) {
+    logError('Failed to update own therapist profile', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '更新檔案失敗，請稍後再試' });
+  }
+});
+
+// POST /api/therapists/me/documents — the logged-in therapist appends an
+// identity/credential document URL (already uploaded via /upload-document).
+router.post('/me/documents', authenticateToken, [
+  body('url').isString().trim().isLength({ min: 1, max: 1000 }).withMessage('文件網址無效'),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const existing = await loadOwnTherapist(req.user.id);
+    if (!existing) {
+      return res.status(404).json({ success: false, error_code: 'NO_THERAPIST_PROFILE', message: '你還沒有諮商師檔案' });
+    }
+    const result = await db.query(
+      `UPDATE therapists
+          SET identity_documents = array_append(identity_documents, $1),
+              identity_status = 'submitted', updated_at = NOW()
+        WHERE id = $2 RETURNING *`,
+      [req.body.url.trim(), existing.id]
+    );
+    logInfo('Therapist document submitted', { userId: req.user.id, therapistId: existing.id });
+    res.status(201).json({ success: true, message: '文件已上傳，等待管理員審核', therapist: toOwnTherapist(result.rows[0]) });
+  } catch (error) {
+    logError('Failed to add therapist document', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '上傳文件失敗，請稍後再試' });
+  }
 });
 
 // GET /api/therapists/consultations/mine — my consultation requests.
@@ -321,16 +648,21 @@ router.get('/:id', optionalAuth, async (req, res) => {
 // --- Apply to become a therapist ----------------------------------------
 
 // POST /api/therapists/apply
-// optionalAuth: a logged-in user gets linked via user_id, but anyone can apply.
+// optionalAuth: a logged-in user gets linked via user_id. Anyone can apply
+// without an account — we provision one for them so they can log in, edit their
+// profile, and manage consultations. The response tells the applicant exactly
+// how to log in (their email, plus a generated password for brand-new accounts).
 router.post('/apply', optionalAuth, [
   body('displayName').isString().trim().isLength({ min: 1, max: 120 }).withMessage('請填寫姓名'),
   body('title').optional({ nullable: true }).isString().isLength({ max: 120 }),
   body('licenseNo').optional({ nullable: true }).isString().isLength({ max: 80 }),
   body('focusAreas').isArray({ min: 1 }).withMessage('請至少選擇一個專長領域'),
+  body('customSpecialties').optional().isArray(),
   body('languages').optional().isArray(),
   body('yearsExperience').optional({ nullable: true }).isInt({ min: 0, max: 80 }).withMessage('年資無效'),
   body('bio').optional({ nullable: true }).isString().isLength({ max: 2000 }),
   body('photoUrl').optional({ nullable: true }).isString().isLength({ max: 1000 }),
+  body('identityDocuments').optional().isArray(),
   body('rateTwd').isInt({ min: 0, max: 100000 }).withMessage('費率無效'),
   body('sessionMinutes').optional().isInt({ min: 10, max: 240 }).withMessage('時長無效'),
   body('contactEmail').isEmail().withMessage('請填寫有效的聯絡 Email'),
@@ -345,26 +677,96 @@ router.post('/apply', optionalAuth, [
 
     const focusAreas = sanitizeStringArray(req.body.focusAreas, FOCUS_AREAS);
     if (focusAreas.length === 0) {
-      return res.status(400).json({ success: false, message: '請至少選擇一個有效的專長領域' });
+      return res.status(400).json({ success: false, error_code: 'NO_FOCUS_AREA', message: '請至少選擇一個有效的專長領域' });
     }
     const langs = sanitizeStringArray(languages);
+    const customSpecialties = sanitizeCustomSpecialties(req.body.customSpecialties);
+    const identityDocuments = sanitizeStringArray(req.body.identityDocuments).slice(0, 10);
+    // Keep the email exactly as entered (trimmed) to match the case-sensitive
+    // register/login flow — so the credentials we hand back log in cleanly.
+    const email = contactEmail.trim();
 
-    const userId = req.user ? req.user.id : null;
+    // --- Resolve / provision the therapist's user account ------------------
+    // Priority: an already-logged-in user → reuse. Else an existing account
+    // matching the contact email → link (don't reset their password). Else
+    // create a fresh account and hand back generated credentials.
+    let userId = req.user ? req.user.id : null;
+    let credentials = null;          // { email, password } for brand-new accounts
+    let accountExisted = false;      // true when we linked to a pre-existing login
+
+    if (!userId) {
+      const existing = await db.query('SELECT id FROM users WHERE email = $1', [email]);
+      if (existing.rows.length > 0) {
+        userId = existing.rows[0].id;
+        accountExisted = true;
+      } else {
+        const tempPassword = generateTempPassword();
+        const passwordHash = await bcrypt.hash(tempPassword, 12);
+        const newId = uuidv4();
+        const now = new Date().toISOString();
+        // nickname must satisfy the 2-50 char rule used elsewhere; clamp.
+        const nickname = displayName.trim().slice(0, 50).padEnd(2, '　');
+        const created = await db.query(
+          `INSERT INTO users (id, nickname, email, password_hash, created_at, last_login)
+           VALUES ($1, $2, $3, $4, $5, $5) RETURNING id`,
+          [newId, nickname, email, passwordHash, now]
+        );
+        userId = created.rows[0].id;
+        credentials = { email, password: tempPassword };
+      }
+    }
+
+    // Block a duplicate active profile for the same account so /me stays
+    // unambiguous and admins don't see dupes. Rejected ones can be re-applied.
+    if (userId) {
+      const dupe = await db.query(
+        `SELECT id, status FROM therapists
+          WHERE user_id = $1 AND status IN ('pending','approved','suspended')
+          ORDER BY created_at DESC LIMIT 1`,
+        [userId]
+      );
+      if (dupe.rows.length > 0) {
+        logInfo('Therapist apply blocked: existing profile', { userId, status: dupe.rows[0].status });
+        return res.status(409).json({
+          success: false,
+          error_code: 'THERAPIST_PROFILE_EXISTS',
+          message: '這個帳號已經有一份諮商師申請或檔案了。請登入後到「我的諮商師檔案」編輯，不需重複申請。',
+        });
+      }
+    }
+
+    // Email verification token — emailed to the contact address. We mark the
+    // profile verified only after they click the link.
+    const verifyToken = crypto.randomBytes(24).toString('hex');
+    const identityStatus = identityDocuments.length > 0 ? 'submitted' : 'unverified';
 
     const result = await db.query(`
       INSERT INTO therapists
-        (user_id, display_name, title, license_no, focus_areas, languages,
-         years_experience, bio, photo_url, rate_twd, session_minutes,
-         contact_email, contact_phone, status)
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,'pending')
+        (user_id, display_name, title, license_no, focus_areas, custom_specialties,
+         languages, years_experience, bio, photo_url, rate_twd, session_minutes,
+         contact_email, contact_phone, identity_documents, identity_status,
+         email_verification_token, email_verification_sent_at, status)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,NOW(),'pending')
       RETURNING id, status, created_at
     `, [
-      userId, displayName.trim(), title || null, licenseNo || null, focusAreas, langs,
-      yearsExperience ?? null, bio || null, photoUrl || null, rateTwd,
-      sessionMinutes ?? 50, contactEmail.trim(), contactPhone || null,
+      userId, displayName.trim(), title || null, licenseNo || null, focusAreas, customSpecialties,
+      langs, yearsExperience ?? null, bio || null, photoUrl || null, rateTwd,
+      sessionMinutes ?? 50, email, contactPhone || null, identityDocuments, identityStatus,
+      verifyToken,
     ]);
 
-    logInfo('Therapist application submitted', { userId, therapistId: result.rows[0].id });
+    // Fire-and-forget the verification email — sign-up must succeed even if SMTP
+    // is down. The applicant still gets their credentials in the response.
+    emailService.sendTherapistEmailVerification({
+      recipientEmail: email,
+      displayName: displayName.trim(),
+      token: verifyToken,
+    }).catch((err) => logWarn('Therapist verification email failed', { err: err.message }));
+
+    logInfo('Therapist application submitted', {
+      userId, therapistId: result.rows[0].id, accountCreated: !!credentials, accountExisted,
+    });
+
     res.status(201).json({
       success: true,
       message: '申請已送出，我們會在審核後與你聯繫',
@@ -373,9 +775,18 @@ router.post('/apply', optionalAuth, [
         status: result.rows[0].status,
         createdAt: result.rows[0].created_at,
       },
+      // Login guidance for the applicant. `credentials` is only present for a
+      // freshly-created account; never echo a password for an existing login.
+      account: {
+        email,
+        created: !!credentials,
+        existed: accountExisted,
+        password: credentials ? credentials.password : null,
+      },
+      emailVerificationSent: true,
     });
   } catch (error) {
-    logError('Failed to submit therapist application', { err: error.message });
+    logError('Failed to submit therapist application', { err: error.message, stack: error.stack });
     res.status(500).json({ success: false, message: '送出申請失敗，請稍後再試' });
   }
 });
@@ -441,10 +852,11 @@ router.post('/:id/consult', authenticateToken, [
 
 // --- Admin moderation (Basic-Auth gated in server.js) -------------------
 
-// GET /api/admin/therapists?status=pending — review queue.
+// GET /api/admin/therapists?status=pending — review queue. 'suspended' is a
+// valid filter so admins can find and reactivate paused therapists.
 adminRouter.get('/', async (req, res) => {
   try {
-    const status = ['pending', 'approved', 'rejected'].includes(req.query.status)
+    const status = ['pending', 'approved', 'rejected', 'suspended'].includes(req.query.status)
       ? req.query.status : 'pending';
     const result = await db.query(
       `SELECT * FROM therapists WHERE status = $1 ORDER BY created_at DESC`,
@@ -457,14 +869,28 @@ adminRouter.get('/', async (req, res) => {
   }
 });
 
-// POST /api/admin/therapists/:id/review { action: 'approve'|'reject', note }
+// POST /api/admin/therapists/:id/review
+//   { action: 'approve'|'reject'|'suspend'|'reactivate', note }
+//   - approve    : pending/suspended → approved (visible in browse)
+//   - reject     : → rejected (never approved, or removed from the listing)
+//   - suspend    : approved → suspended (temporarily hidden, recoverable)
+//   - reactivate : suspended → approved (un-pause)
+const REVIEW_STATUS = {
+  approve: 'approved',
+  reject: 'rejected',
+  suspend: 'suspended',
+  reactivate: 'approved',
+};
 adminRouter.post('/:id/review', express.json(), async (req, res) => {
   try {
     const action = req.body && req.body.action;
-    if (!['approve', 'reject'].includes(action)) {
-      return res.status(400).json({ success: false, message: "action must be 'approve' or 'reject'" });
+    const status = REVIEW_STATUS[action];
+    if (!status) {
+      return res.status(400).json({
+        success: false,
+        message: "action must be one of 'approve' | 'reject' | 'suspend' | 'reactivate'",
+      });
     }
-    const status = action === 'approve' ? 'approved' : 'rejected';
     const result = await db.query(
       `UPDATE therapists
           SET status = $1, review_note = $2, reviewed_at = NOW(), updated_at = NOW()
@@ -475,11 +901,57 @@ adminRouter.post('/:id/review', express.json(), async (req, res) => {
     if (result.rows.length === 0) {
       return res.status(404).json({ success: false, message: 'Therapist not found' });
     }
-    logInfo('Admin reviewed therapist', { id: req.params.id, status });
+    logInfo('Admin reviewed therapist', { id: req.params.id, action, status });
     res.json({ success: true, therapist: result.rows[0] });
   } catch (error) {
     logError('Admin: failed to review therapist', { id: req.params.id, err: error.message });
     res.status(500).json({ success: false, message: 'Failed to review therapist' });
+  }
+});
+
+// POST /api/admin/therapists/:id/verify-identity { action: 'verify'|'reject', note }
+// Admin confirms or rejects the uploaded credential documents, independent of
+// the listing status.
+adminRouter.post('/:id/verify-identity', express.json(), async (req, res) => {
+  try {
+    const action = req.body && req.body.action;
+    if (!['verify', 'reject'].includes(action)) {
+      return res.status(400).json({ success: false, message: "action must be 'verify' or 'reject'" });
+    }
+    const identityStatus = action === 'verify' ? 'verified' : 'rejected';
+    const result = await db.query(
+      `UPDATE therapists SET identity_status = $1, updated_at = NOW()
+        WHERE id = $2 RETURNING id, identity_status`,
+      [identityStatus, req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ success: false, message: 'Therapist not found' });
+    }
+    logInfo('Admin reviewed therapist identity', { id: req.params.id, identityStatus });
+    res.json({ success: true, therapist: result.rows[0] });
+  } catch (error) {
+    logError('Admin: failed to verify therapist identity', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to verify identity' });
+  }
+});
+
+// DELETE /api/admin/therapists/:id — permanently remove a therapist profile.
+// Their consultations cascade-delete (FK ON DELETE CASCADE from migration 041);
+// the linked user account is left intact. Use suspend for a reversible hide.
+adminRouter.delete('/:id', async (req, res) => {
+  try {
+    const result = await db.query(
+      `DELETE FROM therapists WHERE id = $1 RETURNING id, display_name`,
+      [req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ success: false, message: 'Therapist not found' });
+    }
+    logWarn('Admin deleted therapist', { id: req.params.id, displayName: result.rows[0].display_name });
+    res.json({ success: true, message: 'Therapist deleted', id: result.rows[0].id });
+  } catch (error) {
+    logError('Admin: failed to delete therapist', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to delete therapist' });
   }
 });
 

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -764,6 +764,62 @@ ${message ? `個人訊息："${message}"` : ''}
     }
   }
 
+  // Send a therapist their email-verification link after they sign up. The
+  // link points at the public GET /api/therapists/verify-email?token=… route,
+  // which flips email_verified true and shows a confirmation page.
+  async sendTherapistEmailVerification({ recipientEmail, displayName, token }) {
+    if (!this.isConfigured()) {
+      logWarn('Email service not configured; skipping therapist verification email', { kind: 'therapist_verify' });
+      return;
+    }
+    if (!recipientEmail || !token) return;
+
+    const frontendUrl = process.env.FRONTEND_URL || 'https://twogether-couples-app.de.r.appspot.com';
+    const verifyUrl = `${frontendUrl}/api/therapists/verify-email?token=${encodeURIComponent(token)}`;
+    const safeName = this._escape(displayName || '諮商師');
+
+    const bodyHtml = `
+      <p>${safeName} 你好，</p>
+      <p>感謝你申請成為 Twogether 平台的諮商心理師。請點擊下方按鈕驗證這個 Email 是你本人的，我們才能在審核通過後與你聯繫。</p>
+      <p style="color:#636e72;font-size:14px;">如果按鈕無法點擊，請複製以下連結到瀏覽器：<br>
+        <code style="background:#f8f9fa;padding:4px 6px;border-radius:4px;word-break:break-all;">${verifyUrl}</code>
+      </p>
+    `;
+    const html = this._activityEmailHtml({
+      headerEmoji: '🩺',
+      headerTitle: '驗證你的 Email',
+      headerSubtitle: 'Twogether 心理諮商',
+      bodyHtml,
+      ctaLabel: '✓ 驗證我的 Email',
+    }).replace(
+      process.env.FRONTEND_URL || 'https://twogether-couples-app.de.r.appspot.com',
+      verifyUrl
+    );
+
+    const text = [
+      `${displayName || '諮商師'} 你好，`,
+      '',
+      '感謝你申請成為 Twogether 平台的諮商心理師。',
+      '請點擊以下連結驗證你的 Email：',
+      verifyUrl,
+      '',
+      '— Twogether 心理諮商',
+    ].join('\n');
+
+    try {
+      await this.transporter.sendMail({
+        from: `"Twogether 心理諮商" <${process.env.SMTP_USER}>`,
+        to: recipientEmail,
+        subject: '🩺 請驗證你的 Email · Twogether 諮商師申請',
+        text,
+        html,
+      });
+      logInfo('Therapist verification email sent', { kind: 'therapist_verify' });
+    } catch (error) {
+      logError('Failed to send therapist verification email', { kind: 'therapist_verify', ...smtpErrorFields(error) });
+    }
+  }
+
   async sendIntimacyResponseNotification({ receiverName, senderEmail, response, responseMessage = '' }) {
     if (!this.isConfigured()) return;
     if (!senderEmail) return;

--- a/src/components/TherapistsView.tsx
+++ b/src/components/TherapistsView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Heart, Sparkles, X, UserPlus, Clock, Languages, Award, CalendarCheck, MessageCircle, Send, StickyNote } from 'lucide-react';
+import { Heart, Sparkles, X, UserPlus, Clock, Languages, Award, CalendarCheck, MessageCircle, Send, StickyNote, UserCog, Upload, CheckCircle2, AlertCircle } from 'lucide-react';
 import {
   apiService,
   type Therapist,
@@ -7,6 +7,8 @@ import {
   type TherapistConsultation,
   type ConsultationThread,
   type EventRecord,
+  type OwnTherapistProfile,
+  type TherapistProfileUpdate,
 } from '../services/api';
 import type { Notification } from './ErrorNotification';
 import { useScrollLock } from '../hooks/useScrollLock';
@@ -32,6 +34,12 @@ const FOCUS_AREAS: { id: TherapistFocusArea; label: string; emoji: string }[] = 
   { id: 'parenting', label: '親職教養', emoji: '👶' },
   { id: 'grief', label: '悲傷失落', emoji: '🕊️' },
   { id: 'anxiety', label: '焦慮憂鬱', emoji: '🌧️' },
+  { id: 'depression', label: '憂鬱情緒', emoji: '🌫️' },
+  { id: 'trauma', label: '創傷', emoji: '💔' },
+  { id: 'addiction', label: '成癮', emoji: '🎯' },
+  { id: 'lgbtq', label: '性別與多元認同', emoji: '🏳️‍🌈' },
+  { id: 'career', label: '職涯/工作壓力', emoji: '💼' },
+  { id: 'self_esteem', label: '自我價值', emoji: '✨' },
 ];
 
 const focusLabel = (id: string): string =>
@@ -66,6 +74,22 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
   const [chatTarget, setChatTarget] = useState<TherapistConsultation | null>(null);
   const [consultations, setConsultations] = useState<TherapistConsultation[]>([]);
   const [consultationsLoaded, setConsultationsLoaded] = useState(false);
+
+  // The logged-in user's own therapist profile (if they are a therapist), so we
+  // can offer a "我的諮商師檔案" editor.
+  const [ownProfile, setOwnProfile] = useState<OwnTherapistProfile | null>(null);
+  const [showProfileEditor, setShowProfileEditor] = useState(false);
+
+  const loadOwnProfile = useCallback(async () => {
+    if (!authState.isAuthenticated) { setOwnProfile(null); return; }
+    try {
+      setOwnProfile(await apiService.getMyTherapistProfile());
+    } catch {
+      setOwnProfile(null);
+    }
+  }, [authState.isAuthenticated]);
+
+  useEffect(() => { loadOwnProfile(); }, [loadOwnProfile]);
 
   const loadTherapists = useCallback(async () => {
     try {
@@ -152,6 +176,16 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
             我的預約{pendingCount > 0 ? ` (${pendingCount})` : ''}
           </button>
         )}
+        {authState.isAuthenticated && ownProfile && (
+          <button
+            onClick={() => setShowProfileEditor(true)}
+            data-testid="therapist-myprofile-button"
+            className="flex items-center gap-1.5 px-4 py-2 rounded-full border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors font-body text-[13px] font-medium"
+          >
+            <UserCog className="w-3.5 h-3.5" strokeWidth={1.5} />
+            我的諮商師檔案
+          </button>
+        )}
       </div>
 
       {/* Focus filter */}
@@ -233,6 +267,19 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
           showNotification={showNotification}
         />
       )}
+
+      {showProfileEditor && ownProfile && (
+        <ProfileEditorModal
+          profile={ownProfile}
+          onClose={() => setShowProfileEditor(false)}
+          onSaved={(updated) => {
+            setOwnProfile(updated);
+            loadTherapists();
+            showNotification({ type: 'success', title: '檔案已更新', message: '你的諮商師檔案已儲存', duration: 3000 });
+          }}
+          showNotification={showNotification}
+        />
+      )}
     </div>
   );
 };
@@ -305,6 +352,14 @@ const TherapistCard: React.FC<{ therapist: Therapist; onBook: () => void }> = ({
               className="px-2 py-0.5 rounded-full bg-petal-cream-2 border border-petal-rule font-body text-[11px] text-petal-ink-soft"
             >
               {focusLabel(a)}
+            </span>
+          ))}
+          {(therapist.customSpecialties || []).map((s) => (
+            <span
+              key={s}
+              className="px-2 py-0.5 rounded-full bg-pink-50 border border-pink-200 font-body text-[11px] text-pink-700"
+            >
+              {s}
             </span>
           ))}
         </div>
@@ -734,6 +789,290 @@ const ChatRoom: React.FC<{
         </div>
       )}
     </div>
+  );
+};
+
+// --- Therapist profile editor (self-service) ------------------------------
+
+const STATUS_LABEL: Record<OwnTherapistProfile['status'], { label: string; cls: string }> = {
+  pending: { label: '審核中', cls: 'text-petal-rose-deep' },
+  approved: { label: '已上架', cls: 'text-petal-sage-deep' },
+  suspended: { label: '已暫停（暫時下架）', cls: 'text-petal-muted' },
+  rejected: { label: '未通過', cls: 'text-petal-muted' },
+};
+
+const IDENTITY_LABEL: Record<string, string> = {
+  unverified: '尚未提交文件',
+  submitted: '文件審核中',
+  verified: '身分已驗證',
+  rejected: '文件已退回',
+};
+
+const ProfileEditorModal: React.FC<{
+  profile: OwnTherapistProfile;
+  onClose: () => void;
+  onSaved: (updated: OwnTherapistProfile) => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ profile, onClose, onSaved, showNotification }) => {
+  const [displayName, setDisplayName] = useState(profile.displayName);
+  const [title, setTitle] = useState(profile.title || '');
+  const [focusAreas, setFocusAreas] = useState<TherapistFocusArea[]>(profile.focusAreas);
+  const [customSpecialties, setCustomSpecialties] = useState<string[]>(profile.customSpecialties || []);
+  const [customDraft, setCustomDraft] = useState('');
+  const [bio, setBio] = useState(profile.bio || '');
+  const [rateTwd, setRateTwd] = useState(String(profile.rateTwd));
+  const [sessionMinutes, setSessionMinutes] = useState(String(profile.sessionMinutes));
+  const [yearsExperience, setYearsExperience] = useState(
+    profile.yearsExperience != null ? String(profile.yearsExperience) : ''
+  );
+  const [contactPhone, setContactPhone] = useState(profile.contactPhone || '');
+  const [photoUrl, setPhotoUrl] = useState(profile.photoUrl || '');
+  const [documents, setDocuments] = useState<string[]>(profile.identityDocuments || []);
+  const [identityStatus, setIdentityStatus] = useState(profile.identityStatus);
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
+  const [uploadingDoc, setUploadingDoc] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const toggleFocus = (id: TherapistFocusArea) => {
+    setFocusAreas((prev) => (prev.includes(id) ? prev.filter((f) => f !== id) : [...prev, id]));
+  };
+
+  const addCustom = () => {
+    const v = customDraft.trim().slice(0, 40);
+    if (!v || customSpecialties.length >= 8) { setCustomDraft(''); return; }
+    if (!customSpecialties.includes(v)) setCustomSpecialties([...customSpecialties, v]);
+    setCustomDraft('');
+  };
+
+  const uploadPhoto = async (file: File) => {
+    try {
+      setUploadingPhoto(true);
+      setPhotoUrl(await apiService.uploadTherapistAsset(file, 'photo'));
+    } catch (err) {
+      showNotification({ type: 'error', title: '上傳失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 4000 });
+    } finally {
+      setUploadingPhoto(false);
+    }
+  };
+
+  const uploadDoc = async (file: File) => {
+    try {
+      setUploadingDoc(true);
+      const url = await apiService.uploadTherapistAsset(file, 'document');
+      const updated = await apiService.addMyTherapistDocument(url);
+      setDocuments(updated.identityDocuments);
+      setIdentityStatus(updated.identityStatus);
+      showNotification({ type: 'success', title: '文件已上傳', message: '等待管理員審核', duration: 3000 });
+    } catch (err) {
+      showNotification({ type: 'error', title: '上傳失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 4000 });
+    } finally {
+      setUploadingDoc(false);
+    }
+  };
+
+  const save = async () => {
+    if (!displayName.trim()) {
+      showNotification({ type: 'warning', title: '請填寫姓名', message: '姓名不能為空', duration: 3000 });
+      return;
+    }
+    if (focusAreas.length === 0) {
+      showNotification({ type: 'warning', title: '請選擇專長', message: '請至少選擇一個專長領域', duration: 3000 });
+      return;
+    }
+    const payload: TherapistProfileUpdate = {
+      displayName: displayName.trim(),
+      title: title.trim() || null,
+      focusAreas,
+      customSpecialties,
+      bio: bio.trim() || null,
+      photoUrl: photoUrl || null,
+      rateTwd: Number(rateTwd) || 0,
+      sessionMinutes: Number(sessionMinutes) || 50,
+      yearsExperience: yearsExperience ? Number(yearsExperience) : null,
+      contactPhone: contactPhone.trim() || null,
+    };
+    try {
+      setSaving(true);
+      const updated = await apiService.updateMyTherapistProfile(payload);
+      onSaved(updated);
+      onClose();
+    } catch (err) {
+      showNotification({ type: 'error', title: '儲存失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 4000 });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const status = STATUS_LABEL[profile.status];
+
+  return (
+    <ModalShell title="我的諮商師檔案" onClose={onClose}>
+      <div className="space-y-4" data-testid="therapist-profile-editor">
+        {/* Status banner */}
+        <div className="rounded-md border border-petal-rule p-3 bg-petal-cream-2 space-y-1.5">
+          <div className="flex items-center justify-between">
+            <span className="font-body text-xs text-petal-muted">上架狀態</span>
+            <span className={`font-body text-xs font-medium ${status.cls}`}>{status.label}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="font-body text-xs text-petal-muted">Email 驗證</span>
+            <span className={`inline-flex items-center gap-1 font-body text-xs font-medium ${profile.emailVerified ? 'text-petal-sage-deep' : 'text-petal-rose-deep'}`}>
+              {profile.emailVerified
+                ? (<><CheckCircle2 className="w-3.5 h-3.5" strokeWidth={1.5} /> 已驗證</>)
+                : (<><AlertCircle className="w-3.5 h-3.5" strokeWidth={1.5} /> 未驗證（請查收驗證信）</>)}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="font-body text-xs text-petal-muted">身分文件</span>
+            <span className="font-body text-xs font-medium text-petal-ink-soft">{IDENTITY_LABEL[identityStatus] || identityStatus}</span>
+          </div>
+          {profile.reviewNote && (
+            <p className="font-body text-xs text-petal-ink-soft pt-1">管理員備註：{profile.reviewNote}</p>
+          )}
+        </div>
+
+        {/* Photo */}
+        <div>
+          <label className={fieldLabel}>大頭照</label>
+          <div className="flex items-center gap-4">
+            <div className="w-20 h-20 shrink-0 rounded-full overflow-hidden bg-petal-cream-2 border border-petal-rule flex items-center justify-center">
+              {photoUrl
+                ? <img src={photoUrl} alt={displayName} className="w-full h-full object-contain" />
+                : <Heart className="w-7 h-7 text-pink-300" strokeWidth={1.5} />}
+            </div>
+            <label className="cursor-pointer inline-flex items-center gap-1.5 px-3 py-2 rounded-md border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors font-body text-xs">
+              <Upload className="w-3.5 h-3.5" strokeWidth={1.5} />
+              {uploadingPhoto ? '上傳中…' : '更換照片'}
+              <input
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                className="hidden"
+                onChange={(e) => { const f = e.target.files?.[0]; if (f) uploadPhoto(f); }}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className={fieldLabel}>姓名</label>
+            <input value={displayName} onChange={(e) => setDisplayName(e.target.value)} maxLength={120} className={fieldInput} />
+          </div>
+          <div>
+            <label className={fieldLabel}>職稱</label>
+            <input value={title} onChange={(e) => setTitle(e.target.value)} maxLength={120} placeholder="諮商心理師 / 臨床心理師" className={fieldInput} />
+          </div>
+        </div>
+
+        {/* Focus areas */}
+        <div>
+          <label className={fieldLabel}>專長領域</label>
+          <div className="flex flex-wrap gap-1.5">
+            {FOCUS_AREAS.map((f) => (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => toggleFocus(f.id)}
+                className={`flex items-center gap-1 px-3 py-1.5 rounded-full border font-body text-xs transition-colors ${
+                  focusAreas.includes(f.id)
+                    ? 'bg-petal-ink text-petal-cream border-petal-ink'
+                    : 'bg-transparent text-petal-ink-soft border-petal-rule hover:border-petal-ink'
+                }`}
+              >
+                <span>{f.emoji}</span><span>{f.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Custom specialties */}
+        <div>
+          <label className={fieldLabel}>自訂專長 / 取向（最多 8 個）</label>
+          {customSpecialties.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {customSpecialties.map((s) => (
+                <span key={s} className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-pink-50 border border-pink-200 font-body text-[11px] text-pink-700">
+                  {s}
+                  <button type="button" onClick={() => setCustomSpecialties(customSpecialties.filter((x) => x !== s))}>
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <input
+              value={customDraft}
+              onChange={(e) => setCustomDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addCustom(); } }}
+              maxLength={40}
+              placeholder="例如：EMDR、創傷知情、CBT…"
+              className={fieldInput}
+            />
+            <button type="button" onClick={addCustom} className="shrink-0 px-3 rounded-md bg-petal-ink text-petal-cream font-body text-xs">新增</button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className={fieldLabel}>年資</label>
+            <input type="number" min={0} max={80} value={yearsExperience} onChange={(e) => setYearsExperience(e.target.value)} className={fieldInput} />
+          </div>
+          <div>
+            <label className={fieldLabel}>費率 (NT$)</label>
+            <input type="number" min={0} max={100000} value={rateTwd} onChange={(e) => setRateTwd(e.target.value)} className={fieldInput} />
+          </div>
+          <div>
+            <label className={fieldLabel}>時長 (分)</label>
+            <input type="number" min={10} max={240} value={sessionMinutes} onChange={(e) => setSessionMinutes(e.target.value)} className={fieldInput} />
+          </div>
+        </div>
+
+        <div>
+          <label className={fieldLabel}>聯絡電話</label>
+          <input value={contactPhone} onChange={(e) => setContactPhone(e.target.value)} maxLength={40} className={fieldInput} />
+        </div>
+
+        <div>
+          <label className={fieldLabel}>自我介紹</label>
+          <textarea value={bio} onChange={(e) => setBio(e.target.value)} rows={4} maxLength={2000} className={`${fieldInput} resize-none`} />
+        </div>
+
+        {/* Identity documents */}
+        <div>
+          <label className={fieldLabel}>證照 / 身分證明文件</label>
+          {documents.length > 0 && (
+            <div className="space-y-1 mb-2">
+              {documents.map((u, i) => (
+                <a key={u} href={u} target="_blank" rel="noopener noreferrer" className="block font-body text-xs text-pink-600 underline underline-offset-2">
+                  📎 文件 {i + 1}
+                </a>
+              ))}
+            </div>
+          )}
+          <label className="cursor-pointer inline-flex items-center gap-1.5 px-3 py-2 rounded-md border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors font-body text-xs">
+            <Upload className="w-3.5 h-3.5" strokeWidth={1.5} />
+            {uploadingDoc ? '上傳中…' : '上傳文件'}
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/webp,application/pdf"
+              className="hidden"
+              onChange={(e) => { const f = e.target.files?.[0]; if (f) uploadDoc(f); e.target.value = ''; }}
+            />
+          </label>
+          <p className="mt-1.5 font-body text-[11px] text-petal-muted">文件僅供管理員審核，不會公開顯示。</p>
+        </div>
+
+        <button
+          onClick={save}
+          disabled={saving}
+          data-testid="save-therapist-profile"
+          className="w-full py-2.5 rounded-md bg-petal-ink text-petal-cream hover:bg-pink-700 disabled:opacity-50 transition-colors font-body text-sm font-medium"
+        >
+          {saving ? '儲存中…' : '儲存檔案'}
+        </button>
+      </div>
+    </ModalShell>
   );
 };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -675,20 +675,38 @@ apiClient.interceptors.response.use(
 // Human therapist (心理諮商師) directory types
 export type TherapistFocusArea =
   | 'family' | 'couple' | 'childhood' | 'individual'
-  | 'sexuality' | 'parenting' | 'grief' | 'anxiety';
+  | 'sexuality' | 'parenting' | 'grief' | 'anxiety'
+  | 'depression' | 'trauma' | 'addiction' | 'lgbtq'
+  | 'career' | 'self_esteem';
+
+export type TherapistIdentityStatus = 'unverified' | 'submitted' | 'verified' | 'rejected';
 
 export interface Therapist {
   id: string;
   displayName: string;
   title?: string | null;
   focusAreas: TherapistFocusArea[];
+  customSpecialties?: string[];
   languages: string[];
   yearsExperience?: number | null;
   bio?: string | null;
   photoUrl?: string | null;
   rateTwd: number;
   sessionMinutes: number;
+  identityStatus?: TherapistIdentityStatus;
   createdAt: string;
+}
+
+// The therapist's own private view of their profile (GET /therapists/me).
+export interface OwnTherapistProfile extends Therapist {
+  licenseNo?: string | null;
+  contactEmail: string;
+  contactPhone?: string | null;
+  status: 'pending' | 'approved' | 'rejected' | 'suspended';
+  reviewNote?: string | null;
+  emailVerified: boolean;
+  identityDocuments: string[];
+  identityStatus: TherapistIdentityStatus;
 }
 
 export interface TherapistApplicationInput {
@@ -696,14 +714,31 @@ export interface TherapistApplicationInput {
   title?: string;
   licenseNo?: string;
   focusAreas: TherapistFocusArea[];
+  customSpecialties?: string[];
   languages?: string[];
   yearsExperience?: number | null;
   bio?: string;
   photoUrl?: string;
+  identityDocuments?: string[];
   rateTwd: number;
   sessionMinutes?: number;
   contactEmail: string;
   contactPhone?: string;
+}
+
+// Fields a therapist may edit on their own profile (PUT /therapists/me).
+export interface TherapistProfileUpdate {
+  displayName?: string;
+  title?: string | null;
+  focusAreas?: TherapistFocusArea[];
+  customSpecialties?: string[];
+  languages?: string[];
+  yearsExperience?: number | null;
+  bio?: string | null;
+  photoUrl?: string | null;
+  rateTwd?: number;
+  sessionMinutes?: number;
+  contactPhone?: string | null;
 }
 
 export interface ConsultationRequestInput {
@@ -2434,6 +2469,56 @@ class ApiService {
     } catch (error: unknown) {
       console.error('Failed to submit therapist application:', error);
       this.throwApiError(error, '送出申請失敗，請稍後再試');
+    }
+  }
+
+  // Self-service therapist profile (logged-in therapist).
+  async getMyTherapistProfile(): Promise<OwnTherapistProfile | null> {
+    try {
+      const response = await apiClient.get('/therapists/me');
+      return response.data?.therapist as OwnTherapistProfile;
+    } catch (error: unknown) {
+      // 404 just means "this user isn't a therapist" — return null, not throw.
+      const code = (error as { response?: { status?: number } })?.response?.status;
+      if (code === 404) return null;
+      console.error('Failed to fetch own therapist profile:', error);
+      this.throwApiError(error, '無法取得諮商師檔案');
+    }
+  }
+
+  async updateMyTherapistProfile(input: TherapistProfileUpdate): Promise<OwnTherapistProfile> {
+    try {
+      const response = await apiClient.put('/therapists/me', input);
+      return response.data?.therapist as OwnTherapistProfile;
+    } catch (error: unknown) {
+      console.error('Failed to update therapist profile:', error);
+      this.throwApiError(error, '更新檔案失敗，請稍後再試');
+    }
+  }
+
+  async addMyTherapistDocument(url: string): Promise<OwnTherapistProfile> {
+    try {
+      const response = await apiClient.post('/therapists/me/documents', { url });
+      return response.data?.therapist as OwnTherapistProfile;
+    } catch (error: unknown) {
+      console.error('Failed to add therapist document:', error);
+      this.throwApiError(error, '上傳文件失敗，請稍後再試');
+    }
+  }
+
+  // Upload a therapist photo (kind='photo') or credential document
+  // (kind='document'). Public endpoints (used by the no-login sign-up form too).
+  async uploadTherapistAsset(file: File, kind: 'photo' | 'document'): Promise<string> {
+    try {
+      const form = new FormData();
+      form.append(kind, file);
+      const response = await apiClient.post(`/therapists/upload-${kind}`, form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      return response.data?.url as string;
+    } catch (error: unknown) {
+      console.error('Failed to upload therapist asset:', error);
+      this.throwApiError(error, '上傳失敗，請稍後再試');
     }
   }
 


### PR DESCRIPTION
## Summary

Grows the human-therapist directory from a "public form → admin approve/reject" flow into a full account-backed experience covering all five requested capabilities.

### 1. Admin can suspend / delete approved therapists
- Review endpoint extended with `suspend` / `reactivate` actions; new `DELETE /api/admin/therapists/:id` (consultations cascade-delete; the linked user account is kept).
- Admin dashboard gains suspend/reactivate/delete buttons (status-dependent), a **已暫停** filter, email-verification badges, and links to uploaded documents.

### 2. Sign-up page: photo upload, more categories, custom expertise
- Profile-photo upload with live preview.
- 6 new focus categories (憂鬱情緒 / 創傷 / 成癮 / 性別與多元認同 / 職涯 / 自我價值).
- Free-text **custom specialty** tag input (max 8), shown on cards and in admin.

### 3. Account credentials + self-service profile editing
- Sign-up provisions a login account and the success panel **displays the email + generated temporary password**; existing-email and already-logged-in cases are handled without overwriting passwords.
- New in-app **我的諮商師檔案** editor (`GET`/`PUT /api/therapists/me`, `POST /me/documents`) to edit name, rate, photo, specialties, bio, phone, etc.

### 4. Email verification
- Tokenised link `GET /api/therapists/verify-email` flips `email_verified` and renders a confirmation page; sent via new `emailService.sendTherapistEmailVerification`.

### 5. Identity / credential documents
- Public `/upload-photo` and `/upload-document` endpoints (size/type limits, per-IP rate limiting, sharp normalisation for images).
- Admins can view documents and verify/reject identity via `/verify-identity` (`identity_status`).

### Schema
- Migration `044_therapist_accounts.sql`: `custom_specialties`, email-verification columns, `identity_documents` / `identity_status`, `suspended` status, and a per-user index.

## Conventions
All new gates surface a specific `error_code` + actionable message and log via `lib/logger`, per `CLAUDE.md`.

## Testing
Verified against a local Postgres: migration applies cleanly; apply → login (with generated creds) → edit profile → admin approve/suspend/reactivate/verify-identity/delete → email verification → photo/document uploads all work end-to-end. `tsc -b`, `vite build`, and backend ESLint pass. (Two pre-existing frontend lint warnings are unrelated to this change.)

## Note / follow-up
Identity documents are stored in the existing **public** Supabase bucket with unguessable UUID filenames (consistent with current photo handling). For sensitive certificates, a private bucket with signed URLs would be the proper hardening — recommended as a follow-up.

https://claude.ai/code/session_01ExsvPJM4wHN28ChJQZ3yUv

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExsvPJM4wHN28ChJQZ3yUv)_