### PR TITLE
fix(db): reconcile staging migration ledger after 041→043 renumber

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -247,6 +247,14 @@ jobs:
         with:
           project_id: ${{ env.PROJECT_ID }}
 
+      - name: Reconcile Staging Migration Ledger
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          NODE_ENV: production
+        run: |
+          echo "🔧 Reconciling staging migration ledger (guarded, idempotent)..."
+          node scripts/repair-migration-ledger.js
+
       - name: Run Staging Database Migrations
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}

--- a/database/migrator.js
+++ b/database/migrator.js
@@ -69,11 +69,19 @@ class Migrator {
         // Execute the migration
         await client.query(sql);
 
-        // Record the migration
+        // Record the migration. UPSERT so a prior failed attempt (which leaves
+        // a success=false row for this version) doesn't wedge the retry with a
+        // duplicate-key error on the primary key.
         const executionTime = Date.now() - startTime;
         await client.query(`
           INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time)
           VALUES ($1, $2, NOW(), true, $3, $4)
+          ON CONFLICT (version) DO UPDATE SET
+            description = EXCLUDED.description,
+            installed_on = EXCLUDED.installed_on,
+            success = EXCLUDED.success,
+            checksum = EXCLUDED.checksum,
+            execution_time = EXCLUDED.execution_time
         `, [migration.version, migration.description, checksum, executionTime]);
       });
 
@@ -88,6 +96,12 @@ class Migrator {
         await db.query(`
           INSERT INTO _sqlx_migrations (version, description, installed_on, success, checksum, execution_time)
           VALUES ($1, $2, NOW(), false, $3, $4)
+          ON CONFLICT (version) DO UPDATE SET
+            description = EXCLUDED.description,
+            installed_on = EXCLUDED.installed_on,
+            success = EXCLUDED.success,
+            checksum = EXCLUDED.checksum,
+            execution_time = EXCLUDED.execution_time
         `, [migration.version, migration.description, Buffer.alloc(0), executionTime]);
       } catch (recordError) {
         console.error('Failed to record migration failure:', recordError.message);

--- a/scripts/repair-migration-ledger.js
+++ b/scripts/repair-migration-ledger.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+//
+// Idempotent, guarded repair for `_sqlx_migrations` ledger drift.
+//
+// Background: the coupons migration was renumbered 041 -> 043 (commit 6b167cf)
+// so that 041 could become `041_therapists`. Any database that had already
+// applied the OLD 041 (coupons) keeps a `version = 41` row whose content no
+// longer matches the file on disk. The runner skips version 41, so the new
+// `041_therapists` never runs, and `042_consultation_chat` then fails with
+// `relation "therapist_consultations" does not exist`. The failed attempt also
+// leaves a `success = false` row that wedges retries with a duplicate-key error.
+//
+// This script reconciles that drift WITHOUT touching healthy databases:
+//   1. Delete any `success = false` rows so failed attempts retry cleanly.
+//   2. ONLY IF the `therapists` table is missing (the unambiguous signal that
+//      version 41 is the pre-renumber coupons row, not the therapists one),
+//      delete ledger rows for version >= 41 so the correctly-numbered
+//      041..044 re-apply. All of 041..044 are idempotent (CREATE ... IF NOT
+//      EXISTS, ADD COLUMN IF NOT EXISTS, INSERT ... ON CONFLICT DO NOTHING),
+//      so re-applying over the already-present coupons tables is a no-op.
+//
+// On a healthy database (therapists table present) step 2 is skipped, so this
+// is safe to run on production / on every deploy — it self-disables once the
+// ledger is consistent.
+require('dotenv').config();
+const db = require('../database/db');
+
+async function main() {
+  const url = process.env.DATABASE_URL || '';
+  console.log('🔧 Repairing migration ledger on:', url.replace(/(:\/\/[^:]+:)[^@]+(@)/, '$1***$2') || '(no DATABASE_URL)');
+
+  await db.transaction(async (client) => {
+    const failed = await client.query('DELETE FROM _sqlx_migrations WHERE success = false RETURNING version');
+    if (failed.rowCount > 0) {
+      console.log(`  • cleared ${failed.rowCount} failed migration row(s): ${failed.rows.map(r => r.version).join(', ')}`);
+    } else {
+      console.log('  • no failed migration rows to clear');
+    }
+
+    const { rows } = await client.query("SELECT to_regclass('public.therapists') AS reg");
+    const therapistsExists = rows[0].reg !== null;
+
+    if (therapistsExists) {
+      console.log('  • therapists table present — ledger is consistent, no drift repair needed');
+      return;
+    }
+
+    const drift = await client.query('DELETE FROM _sqlx_migrations WHERE version >= 41 RETURNING version');
+    console.log(`  • therapists table missing — removed stale ledger row(s) for version >= 41: ${drift.rows.map(r => r.version).join(', ') || '(none)'}`);
+    console.log('  • migrations 041..044 will now re-apply on the next `npm run migrate` (all idempotent)');
+  });
+
+  console.log('✅ Ledger repair complete');
+}
+
+main()
+  .then(async () => { await db.close(); process.exit(0); })
+  .catch(async (err) => {
+    console.error('❌ Ledger repair failed:', err.message);
+    try { await db.close(); } catch { /* ignore */ }
+    process.exit(1);
+  });


### PR DESCRIPTION
## Problem

The `deploy-staging` job fails at `042_consultation_chat` with `relation "therapist_consultations" does not exist`.

Root cause: the coupons migration was renumbered `041 → 043` (commit `6b167cf`) so `041` could become `041_therapists`. Staging had already applied the **old** `041` (coupons), so its `_sqlx_migrations` ledger has a `version = 41` row that no longer matches the file on disk. The runner skips version 41 → `041_therapists` never runs → `042` fails. The failed attempt also left a `success = false` row that wedged retries with a duplicate-key error.

Production is unaffected (it was migrated cleanly after the renumber — verified: v41=therapists, v43=coupons, all tables present).

## Fix

- **`scripts/repair-migration-ledger.js`** — guarded, idempotent reconciliation:
  1. Clears `success = false` rows so failed attempts retry cleanly.
  2. **Only when the `therapists` table is missing** (the unambiguous signal of pre-renumber drift) drops ledger rows for `version >= 41`, so the correctly-numbered `041..044` re-apply. All of `041..044` are idempotent (`CREATE ... IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `INSERT ... ON CONFLICT DO NOTHING`), so re-applying over the already-present coupons tables is a no-op.
  - On a healthy DB (therapists present) it self-disables — **verified as a no-op against production**.
- **`deploy.yml`** — run the repair before the staging migration step.
- **`database/migrator.js`** — UPSERT the ledger row (`ON CONFLICT (version) DO UPDATE`) so a failed migration can no longer wedge its retry with a duplicate-key error.

## Verification

- Repair script run against the live (healthy) DB: no-op as designed — clears 0 failed rows, detects `therapists` present, skips drift repair.
- Once merged, the staging deploy runs repair → migrate, applying `041..044` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)