### PR TITLE
feat(therapists): monetization — public Q&A, paid video sessions, profit-sharing, richer profiles & reviews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -281,6 +281,7 @@ jobs:
           _CORS_ORIGIN: ${{ secrets.CORS_ORIGIN }}
           _LLM_PROVIDER: ${{ vars.LLM_PROVIDER || 'claude' }}
           _ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          _ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
         run: |
           echo "🚀 Deploying PR #${{ github.event.pull_request.number }} to staging..."
           envsubst < app.staging.yaml > app.staging.yaml.tmp && mv app.staging.yaml.tmp app.staging.yaml

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -32,6 +32,9 @@ env_variables:
   # If ANTHROPIC_API_KEY is missing, llmService falls back to the mock.
   LLM_PROVIDER: $_LLM_PROVIDER
   ANTHROPIC_API_KEY: $_ANTHROPIC_API_KEY
+  # Admin dashboard (/admin) Basic-Auth password. Without it, adminAuth returns
+  # 503 "Admin disabled". Shares the prod ADMIN_PASSWORD secret.
+  ADMIN_PASSWORD: $_ADMIN_PASSWORD
 
 automatic_scaling:
   min_instances: 0

--- a/database/migrations/045_consultation_public_qa.sql
+++ b/database/migrations/045_consultation_public_qa.sql
@@ -1,0 +1,60 @@
+-- "公開問答" (Public Q&A): let an existing free consultation chat be published,
+-- read-only and anonymised, so other users can learn from how a therapist
+-- handled a similar problem.
+--
+-- This is NOT a new chatroom — it reuses the existing therapist_consultations
+-- room (041) and its consultation_messages log (042). Publishing is a two-party
+-- consent handshake: one side (the client OR the therapist) proposes it, the
+-- OTHER side approves, and either side can withdraw it again. Once published the
+-- asker is rendered anonymously ("匿名個案"); the therapist is shown, since the
+-- thread showcases their work.
+--
+-- Therapist participation in free chats is also the engagement signal that feeds
+-- the monthly revenue-share pool (migration 047): a therapist's monthly activity
+-- is the count of consultation_messages they sent that month. We add a supporting
+-- index for that aggregation here. "Helpful" votes on published threads are an
+-- additional weighting input we capture now and use when the pool moves off the
+-- initial even split.
+
+ALTER TABLE therapist_consultations
+  -- Publish lifecycle / consent handshake:
+  --   private            : default, room is private to its participants
+  --   client_requested   : the client proposed publishing, awaiting therapist
+  --   therapist_requested: the therapist proposed publishing, awaiting client
+  --   published          : both parties consented, visible in the public list
+  --   withdrawn          : was published/proposed, then pulled back (hidden)
+  ADD COLUMN IF NOT EXISTS public_status VARCHAR(24) NOT NULL DEFAULT 'private',
+  -- Who proposed, who approved (both reference users; SET NULL keeps history if
+  -- an account is deleted). published_at stamps when it went public.
+  ADD COLUMN IF NOT EXISTS public_requested_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS public_approved_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS published_at        TIMESTAMP WITH TIME ZONE,
+  -- Headline shown in the public list, set by whoever proposes publishing. The
+  -- transcript itself is anonymised at render time, never stored differently.
+  ADD COLUMN IF NOT EXISTS public_title        VARCHAR(200);
+
+ALTER TABLE therapist_consultations DROP CONSTRAINT IF EXISTS therapist_consultations_public_status_valid;
+ALTER TABLE therapist_consultations ADD CONSTRAINT therapist_consultations_public_status_valid
+  CHECK (public_status IN ('private', 'client_requested', 'therapist_requested', 'published', 'withdrawn'));
+
+-- Public list is "published consultations, newest first"; partial index keeps it
+-- cheap as private rooms pile up.
+CREATE INDEX IF NOT EXISTS idx_therapist_consultations_published
+  ON therapist_consultations(published_at DESC)
+  WHERE public_status = 'published';
+
+-- "Helpful" votes on a published thread. One vote per (consultation, voter).
+-- Feeds the future engagement-weighted pool split (047).
+CREATE TABLE IF NOT EXISTS consultation_public_votes (
+  consultation_id UUID NOT NULL REFERENCES therapist_consultations(id) ON DELETE CASCADE,
+  voter_id        UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (consultation_id, voter_id)
+);
+
+-- Monthly engagement aggregation for the revenue pool counts each therapist's
+-- messages within a month. The pool query joins consultation_messages.sender_id
+-- to the consultation's therapist user, so indexing (sender_id, created_at)
+-- makes "messages by this user in [month)" cheap.
+CREATE INDEX IF NOT EXISTS idx_consultation_messages_sender_month
+  ON consultation_messages(sender_id, created_at);

--- a/database/migrations/046_session_bookings.sql
+++ b/database/migrations/046_session_bookings.sql
@@ -1,0 +1,96 @@
+-- Paid video sessions (視訊諮商): the charged tier on top of the free chat.
+--
+-- A client who likes a therapist in the free chat books a real-time 1:1 video
+-- session. The video itself is third-party (Zoom / Google Meet) — the platform
+-- only matches the two parties and stores the meeting link the therapist pastes
+-- in after accepting. Payment goes through ECPay (same AioCheckOut helper as the
+-- couple Premium passes); the platform keeps a service fee and the therapist
+-- nets the rest.
+--
+-- Fee: 20% standard, but 10% for a therapist's FIRST 10 completed sessions
+-- (new-therapist intro rate). The fee rate is computed at payment time and
+-- snapshotted onto the booking + order so a later refund/dispute never reprices
+-- a historical session. A booking counts toward the "first 10" only once it is
+-- both paid AND completed (counts_toward_intro), so unpaid/no-show bookings
+-- don't burn intro slots.
+--
+-- The booking reuses the therapist_consultations row (so the existing chat room,
+-- access checks and "my consultations" list all work) — distinguished from the
+-- free flow by booking_type = 'scheduled'.
+
+ALTER TABLE therapist_consultations
+  -- 'free' = the existing no-charge chat consultation; 'scheduled' = a paid
+  -- video booking. Existing rows default to 'free'.
+  ADD COLUMN IF NOT EXISTS booking_type VARCHAR(16) NOT NULL DEFAULT 'free',
+  -- The free chat this paid booking grew out of (the "預約視訊諮商" nudge), for
+  -- context. Nullable; SET NULL keeps the booking if the source chat is removed.
+  ADD COLUMN IF NOT EXISTS source_consultation_id UUID
+    REFERENCES therapist_consultations(id) ON DELETE SET NULL,
+
+  -- Scheduling + third-party video link (therapist pastes after accepting).
+  ADD COLUMN IF NOT EXISTS scheduled_at     TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS duration_minutes INTEGER,            -- snapshot of session_minutes
+  ADD COLUMN IF NOT EXISTS meeting_provider VARCHAR(16),        -- zoom | meet | other
+  ADD COLUMN IF NOT EXISTS meeting_url      TEXT,
+  ADD COLUMN IF NOT EXISTS meeting_set_at   TIMESTAMP WITH TIME ZONE,
+
+  -- Money snapshot (all TWD integers), frozen at charge time.
+  ADD COLUMN IF NOT EXISTS price_twd         INTEGER,           -- what the client pays
+  ADD COLUMN IF NOT EXISTS fee_rate          INTEGER,           -- 10 or 20 (% kept by platform)
+  ADD COLUMN IF NOT EXISTS platform_fee_twd  INTEGER,
+  ADD COLUMN IF NOT EXISTS therapist_net_twd INTEGER,
+  ADD COLUMN IF NOT EXISTS payment_status    VARCHAR(16) NOT NULL DEFAULT 'unpaid',
+  ADD COLUMN IF NOT EXISTS paid_at           TIMESTAMP WITH TIME ZONE,
+  -- True once the session is both paid AND completed — the only state that
+  -- counts toward the therapist's first-10 intro window.
+  ADD COLUMN IF NOT EXISTS counts_toward_intro BOOLEAN NOT NULL DEFAULT false;
+
+-- Allow a 'no_show' outcome alongside the existing statuses.
+ALTER TABLE therapist_consultations DROP CONSTRAINT IF EXISTS therapist_consultations_status_valid;
+ALTER TABLE therapist_consultations ADD CONSTRAINT therapist_consultations_status_valid
+  CHECK (status IN ('pending', 'accepted', 'declined', 'completed', 'cancelled', 'no_show'));
+
+ALTER TABLE therapist_consultations DROP CONSTRAINT IF EXISTS therapist_consultations_booking_type_valid;
+ALTER TABLE therapist_consultations ADD CONSTRAINT therapist_consultations_booking_type_valid
+  CHECK (booking_type IN ('free', 'scheduled'));
+
+ALTER TABLE therapist_consultations DROP CONSTRAINT IF EXISTS therapist_consultations_payment_status_valid;
+ALTER TABLE therapist_consultations ADD CONSTRAINT therapist_consultations_payment_status_valid
+  CHECK (payment_status IN ('unpaid', 'pending', 'paid', 'refunded', 'failed'));
+
+-- Counting a therapist's completed intro sessions must be fast.
+CREATE INDEX IF NOT EXISTS idx_therapist_consultations_intro
+  ON therapist_consultations(therapist_id)
+  WHERE counts_toward_intro = true;
+
+-- One row per ECPay checkout attempt for a session. Mirrors payment_orders (040)
+-- but keyed to a consultation + therapist rather than a couple, so the Premium
+-- pass flow and its couple_id NOT NULL constraint stay untouched. merchant_trade_no
+-- is OUR id sent to ECPay and is what the server-to-server callback matches on;
+-- UNIQUE makes the callback idempotent. The fee split is snapshotted here too.
+CREATE TABLE IF NOT EXISTS session_payment_orders (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  consultation_id   UUID NOT NULL REFERENCES therapist_consultations(id) ON DELETE CASCADE,
+  payer_id          UUID REFERENCES users(id) ON DELETE SET NULL,
+  therapist_id      UUID NOT NULL REFERENCES therapists(id) ON DELETE CASCADE,
+  merchant_trade_no VARCHAR(32) NOT NULL UNIQUE,
+  amount            INTEGER NOT NULL,                       -- = price_twd, what the client pays
+  fee_rate          INTEGER NOT NULL,                       -- 10 | 20 snapshot
+  platform_fee      INTEGER NOT NULL,
+  therapist_net     INTEGER NOT NULL,
+  status            VARCHAR(16) NOT NULL DEFAULT 'pending', -- pending | paid | failed
+  payment_method    VARCHAR(32),                            -- ECPay PaymentType
+  ecpay_trade_no    VARCHAR(32),                            -- ECPay's TradeNo from callback
+  raw_callback      JSONB,                                  -- full callback payload, for audit
+  created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  paid_at           TIMESTAMP WITH TIME ZONE,
+
+  CONSTRAINT session_payment_orders_status_valid CHECK (status IN ('pending', 'paid', 'failed')),
+  CONSTRAINT session_payment_orders_fee_rate_valid CHECK (fee_rate IN (10, 20))
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_payment_orders_consultation
+  ON session_payment_orders(consultation_id);
+
+CREATE INDEX IF NOT EXISTS idx_session_payment_orders_therapist
+  ON session_payment_orders(therapist_id, created_at DESC);

--- a/database/migrations/047_qa_revenue_pool.sql
+++ b/database/migrations/047_qa_revenue_pool.sql
@@ -1,0 +1,58 @@
+-- Monthly revenue-share pool for free-chat / public-Q&A activity.
+--
+-- Therapists answer clients for free in the chat rooms (and some of those become
+-- public 公開問答). To reward that unpaid work, the platform sets aside part of
+-- its monthly revenue and distributes it to the therapists who were active that
+-- month. The split starts EVEN (every active therapist gets the same), and is
+-- designed to move to volume/engagement-weighted later without a data migration:
+-- engagement is derived at compute time from consultation_messages + published
+-- threads + helpful votes (see 045), not stored as a running counter.
+--
+-- IMPORTANT: this pool is paid out MANUALLY. ECPay AioCheckOut only COLLECTS
+-- money — it cannot disburse to therapists. So payout_status here records that an
+-- admin paid a therapist out-of-band; there is no automated bank transfer.
+
+-- One row per month being distributed. pool_twd is entered by an admin (the
+-- platform's chosen revenue slice for that month).
+CREATE TABLE IF NOT EXISTS qa_revenue_pools (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  period_month   DATE NOT NULL UNIQUE,            -- first day of the month, e.g. 2026-06-01
+  pool_twd       INTEGER NOT NULL,               -- admin-entered total to distribute
+  split_strategy VARCHAR(24) NOT NULL DEFAULT 'even', -- even | volume | engagement
+  status         VARCHAR(16) NOT NULL DEFAULT 'draft', -- draft | computed | finalized | paid_out
+  computed_at    TIMESTAMP WITH TIME ZONE,
+  finalized_at   TIMESTAMP WITH TIME ZONE,
+  created_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT qa_revenue_pools_pool_nonneg CHECK (pool_twd >= 0),
+  CONSTRAINT qa_revenue_pools_strategy_valid CHECK (split_strategy IN ('even', 'volume', 'engagement')),
+  CONSTRAINT qa_revenue_pools_status_valid CHECK (status IN ('draft', 'computed', 'finalized', 'paid_out'))
+);
+
+-- Computed per-therapist share for a pool month. Recomputable while the pool is
+-- draft/computed; frozen once finalized. payout_status drives the admin "mark
+-- as paid" step. The engagement snapshot columns (message/published/vote counts)
+-- record what the split was based on, for transparency.
+CREATE TABLE IF NOT EXISTS qa_revenue_shares (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pool_id         UUID NOT NULL REFERENCES qa_revenue_pools(id) ON DELETE CASCADE,
+  therapist_id    UUID NOT NULL REFERENCES therapists(id) ON DELETE CASCADE,
+  message_count   INTEGER NOT NULL DEFAULT 0,     -- free-chat messages this month
+  published_count INTEGER NOT NULL DEFAULT 0,     -- threads published this month
+  vote_count      INTEGER NOT NULL DEFAULT 0,     -- helpful votes received this month
+  weight          NUMERIC(12,4) NOT NULL DEFAULT 0, -- normalized share weight
+  share_twd       INTEGER NOT NULL DEFAULT 0,     -- computed payout amount
+  payout_status   VARCHAR(16) NOT NULL DEFAULT 'unpaid', -- unpaid | paid
+  paid_at         TIMESTAMP WITH TIME ZONE,
+  payout_note     TEXT,                           -- admin note: bank ref / method
+  created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  UNIQUE (pool_id, therapist_id),
+  CONSTRAINT qa_revenue_shares_payout_status_valid CHECK (payout_status IN ('unpaid', 'paid'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_qa_revenue_shares_pool
+  ON qa_revenue_shares(pool_id);
+
+CREATE INDEX IF NOT EXISTS idx_qa_revenue_shares_therapist
+  ON qa_revenue_shares(therapist_id, created_at DESC);

--- a/database/migrations/048_therapist_profile_rich.sql
+++ b/database/migrations/048_therapist_profile_rich.sql
@@ -1,0 +1,61 @@
+-- Richer therapist profiles + client reviews.
+--
+-- The basic profile (041/044) had name, title, focus areas, a short bio and a
+-- rate. Real counselor profiles (e.g. seeingcounseling.com) carry much more: a
+-- personal message to clients, their treatment approach, current positions,
+-- qualifications, training history, published works and articles, plus client
+-- testimonials. This migration grows the therapists row to hold those sections
+-- and adds a moderated reviews table.
+--
+-- Free-text sections are TEXT. List sections that are just lines (positions,
+-- qualifications, training, license lines) are TEXT[] like the existing
+-- focus_areas/custom_specialties. Publications and articles carry a title plus
+-- an optional source/url, so they're JSONB arrays of small objects.
+
+ALTER TABLE therapists
+  -- Long-form narrative sections.
+  ADD COLUMN IF NOT EXISTS intro_message TEXT,   -- 給來談者的一段話 (welcome message)
+  ADD COLUMN IF NOT EXISTS approach      TEXT,   -- 治療取向／治療理念
+  ADD COLUMN IF NOT EXISTS about         TEXT,   -- 認識治療師
+
+  -- Line-list sections (array of strings).
+  ADD COLUMN IF NOT EXISTS certifications     TEXT[] NOT NULL DEFAULT '{}', -- 心理師證照 (license lines)
+  ADD COLUMN IF NOT EXISTS current_positions  TEXT[] NOT NULL DEFAULT '{}', -- 現任
+  ADD COLUMN IF NOT EXISTS qualifications     TEXT[] NOT NULL DEFAULT '{}', -- 專業資格
+  ADD COLUMN IF NOT EXISTS training           TEXT[] NOT NULL DEFAULT '{}', -- 專業訓練
+
+  -- Title + optional source/url. JSONB array of { title, source } / { title, url }.
+  ADD COLUMN IF NOT EXISTS publications JSONB NOT NULL DEFAULT '[]', -- 心理專業著作
+  ADD COLUMN IF NOT EXISTS articles     JSONB NOT NULL DEFAULT '[]', -- 心理專業文章 / 影音訪談
+
+  -- Whether the therapist is currently taking new clients ("不開放新案預約").
+  ADD COLUMN IF NOT EXISTS accepting_new_clients BOOLEAN NOT NULL DEFAULT true;
+
+-- Client reviews / testimonials. Moderated: a review starts 'pending' and only
+-- shows publicly once an admin approves it. reviewer_display is the anonymised
+-- name shown on the profile (e.g. "林O儀"); author_id ties it to the account
+-- that wrote it (for abuse handling), and is never shown publicly.
+CREATE TABLE IF NOT EXISTS therapist_reviews (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  therapist_id     UUID NOT NULL REFERENCES therapists(id) ON DELETE CASCADE,
+  author_id        UUID REFERENCES users(id) ON DELETE SET NULL,
+  reviewer_display VARCHAR(80) NOT NULL,            -- anonymised name shown publicly
+  rating           SMALLINT,                        -- optional 1-5 stars
+  body             TEXT NOT NULL CHECK (char_length(body) BETWEEN 1 AND 4000),
+  status           VARCHAR(16) NOT NULL DEFAULT 'pending', -- pending | approved | hidden
+  created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT therapist_reviews_rating_valid CHECK (rating IS NULL OR rating BETWEEN 1 AND 5),
+  CONSTRAINT therapist_reviews_status_valid CHECK (status IN ('pending', 'approved', 'hidden'))
+);
+
+-- Public profile shows "approved reviews, newest first" for a therapist.
+CREATE INDEX IF NOT EXISTS idx_therapist_reviews_approved
+  ON therapist_reviews(therapist_id, created_at DESC)
+  WHERE status = 'approved';
+
+-- One author leaves at most one review per therapist (enforced in the route too,
+-- but the partial unique index makes it a hard guarantee for real accounts).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_therapist_reviews_author
+  ON therapist_reviews(therapist_id, author_id)
+  WHERE author_id IS NOT NULL;

--- a/lib/qaPool.js
+++ b/lib/qaPool.js
@@ -1,0 +1,68 @@
+// Monthly Q&A revenue-pool split. Distributes a pool of TWD among the therapists
+// who were active in free chats / public Q&A that month.
+//
+// The split strategy is swappable so the platform can start simple (even) and
+// move to engagement-weighted later WITHOUT changing the data model — engagement
+// stats are derived per month and passed in here.
+//   - 'even'       : every active therapist (≥1 message) gets an equal share.
+//   - 'volume'     : weighted by free-chat message count.
+//   - 'engagement' : message count + bonus for published threads + helpful votes.
+//
+// All amounts are integer TWD; the rounding remainder is reconciled onto the
+// largest-weight share so the shares always sum back to exactly poolTwd.
+
+const ENGAGEMENT_PUBLISHED_WEIGHT = 5; // each published thread ~= 5 messages
+const ENGAGEMENT_VOTE_WEIGHT = 2;      // each helpful vote ~= 2 messages
+
+function weightFor(strategy, s) {
+  const messages = Number(s.message_count) || 0;
+  const published = Number(s.published_count) || 0;
+  const votes = Number(s.vote_count) || 0;
+  if (strategy === 'volume') return messages;
+  if (strategy === 'engagement') {
+    return messages + ENGAGEMENT_PUBLISHED_WEIGHT * published + ENGAGEMENT_VOTE_WEIGHT * votes;
+  }
+  // 'even': active = participated at all that month.
+  return messages > 0 || published > 0 ? 1 : 0;
+}
+
+// stats: [{ therapist_id, message_count, published_count, vote_count }]
+// Returns [{ therapist_id, message_count, published_count, vote_count, weight, share_twd }]
+// for therapists with a positive weight only.
+function computeShares(strategy, stats, poolTwd) {
+  const pool = Math.max(0, Math.floor(Number(poolTwd) || 0));
+  const weighted = (stats || [])
+    .map((s) => ({
+      therapist_id: s.therapist_id,
+      message_count: Number(s.message_count) || 0,
+      published_count: Number(s.published_count) || 0,
+      vote_count: Number(s.vote_count) || 0,
+      weight: weightFor(strategy, s),
+    }))
+    .filter((s) => s.weight > 0);
+
+  const totalWeight = weighted.reduce((a, s) => a + s.weight, 0);
+  if (totalWeight <= 0 || pool <= 0) {
+    return weighted.map((s) => ({ ...s, share_twd: 0 }));
+  }
+
+  const shares = weighted.map((s) => ({ ...s, share_twd: Math.floor((pool * s.weight) / totalWeight) }));
+
+  // Reconcile the floor remainder onto the largest-weight share so the shares
+  // sum to exactly the pool (deterministic: ties broken by therapist_id).
+  const distributed = shares.reduce((a, s) => a + s.share_twd, 0);
+  const remainder = pool - distributed;
+  if (remainder > 0) {
+    let top = 0;
+    for (let i = 1; i < shares.length; i += 1) {
+      if (shares[i].weight > shares[top].weight ||
+         (shares[i].weight === shares[top].weight && shares[i].therapist_id < shares[top].therapist_id)) {
+        top = i;
+      }
+    }
+    shares[top].share_twd += remainder;
+  }
+  return shares;
+}
+
+module.exports = { computeShares, ENGAGEMENT_PUBLISHED_WEIGHT, ENGAGEMENT_VOTE_WEIGHT };

--- a/lib/supabase-storage.js
+++ b/lib/supabase-storage.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { logError } = require('./logger');
+const { logError, logInfo } = require('./logger');
 
 // Returns the new-style ("sb_secret_..." / "sb_publishable_...") API key
 // format introduced by Supabase's late-2025 key rotation, vs. the legacy
@@ -10,6 +10,49 @@ function detectKeyFormat(key) {
   if (key.startsWith('sb_publishable_')) return 'new_publishable';
   if (key.startsWith('eyJ')) return 'legacy_jwt';
   return 'unknown';
+}
+
+// Storage auth header strategy (see the long note at the upload call site):
+//   - legacy_jwt: the service_role key IS a JWT → send as Bearer.
+//   - new_secret / new_publishable: NOT JWTs → authenticate via `apikey` only.
+function storageHeaders(supabaseKey, keyFormat, contentType) {
+  const headers = { apikey: supabaseKey, 'Content-Type': contentType };
+  if (keyFormat === 'legacy_jwt') headers.Authorization = `Bearer ${supabaseKey}`;
+  return headers;
+}
+
+// True when a Storage response means "the bucket doesn't exist". Supabase has
+// returned this as an HTTP 400 OR 404 whose JSON body carries error/message
+// "Bucket not found" (and statusCode "404"), so we match on the body, not the
+// HTTP status.
+function isBucketNotFound(response) {
+  const d = response && response.data;
+  if (!d) return false;
+  const text = typeof d === 'string' ? d : JSON.stringify(d);
+  return /bucket not found/i.test(text);
+}
+
+// Create a public storage bucket. Idempotent: an "already exists" response is
+// treated as success (handles a race between two concurrent first-uploads).
+// Buckets are created public because callers serve files via the
+// `/object/public/<bucket>/...` URL the upload returns.
+async function ensureBucket(supabaseUrl, supabaseKey, keyFormat, bucket) {
+  const response = await axios.post(
+    `${supabaseUrl}/storage/v1/bucket`,
+    { id: bucket, name: bucket, public: true },
+    { headers: storageHeaders(supabaseKey, keyFormat, 'application/json'), validateStatus: () => true }
+  );
+  const ok = response.status >= 200 && response.status < 300;
+  const alreadyExists = !ok && /already exists/i.test(
+    typeof response.data === 'string' ? response.data : JSON.stringify(response.data || '')
+  );
+  if (!ok && !alreadyExists) {
+    logError('supabase-storage ensureBucket failed', { status: response.status, responseData: response.data, bucket });
+    const err = new Error(`Failed to create bucket "${bucket}" (status ${response.status})`);
+    err.code = 'SUPABASE_BUCKET_CREATE_FAILED';
+    throw err;
+  }
+  logInfo('supabase-storage bucket ready', { bucket, created: ok, alreadyExists });
 }
 
 async function uploadToSupabase(fileBuffer, fileName, mimeType, bucket = 'photos') {
@@ -35,32 +78,28 @@ async function uploadToSupabase(fileBuffer, fileName, mimeType, bucket = 'photos
   const uploadUrl = `${supabaseUrl}/storage/v1/object/${bucket}/${fileName}`;
   const keyFormat = detectKeyFormat(supabaseKey);
 
-  // Storage auth header strategy:
-  //   - legacy_jwt: the service_role key IS a JWT, so the Storage gateway
-  //     validates it via `Authorization: Bearer <jwt>` and reads the
-  //     service_role claim. Keep that path for back-compat.
-  //   - new_secret / new_publishable: post-Oct-2025 rotation. These keys
-  //     are NOT JWTs. The Storage gateway authenticates them via the
-  //     `apikey` header; sending them in `Authorization: Bearer` makes
-  //     it try (and fail) to parse them as JWTs, producing a 403 with
-  //     {"error":"Unauthorized","message":"Invalid Compact JWS"} — which
-  //     is exactly what was 500ing /api/custom-scripts/:id on prod.
+  // See storageHeaders() for the apikey-vs-Bearer rationale (post-Oct-2025 key
+  // rotation: new-format keys are NOT JWTs and must go in `apikey`, not Bearer).
   const headers = {
-    apikey: supabaseKey,
-    'Content-Type': mimeType,
+    ...storageHeaders(supabaseKey, keyFormat, mimeType),
     'Content-Length': fileBuffer.length,
   };
-  if (keyFormat === 'legacy_jwt') {
-    headers.Authorization = `Bearer ${supabaseKey}`;
-  }
+
+  // Inspect 4xx responses ourselves rather than letting axios throw before we
+  // can read the body.
+  const doUpload = () => axios.post(uploadUrl, fileBuffer, { headers, validateStatus: () => true });
 
   try {
-    const response = await axios.post(uploadUrl, fileBuffer, {
-      headers,
-      // Inspect 4xx responses ourselves rather than letting axios throw
-      // before we can log the body.
-      validateStatus: () => true,
-    });
+    let response = await doUpload();
+
+    // Self-heal a missing bucket: on a fresh environment (e.g. a new staging
+    // Supabase project) the bucket may not exist yet. Create it (public) and
+    // retry once, so uploads work without a manual dashboard step.
+    if ((response.status < 200 || response.status >= 300) && isBucketNotFound(response)) {
+      logInfo('supabase-storage bucket missing; creating then retrying', { bucket, fileName });
+      await ensureBucket(supabaseUrl, supabaseKey, keyFormat, bucket);
+      response = await doUpload();
+    }
 
     if (response.status < 200 || response.status >= 300) {
       logError('supabase-storage upload rejected', {
@@ -109,4 +148,4 @@ async function uploadToSupabase(fileBuffer, fileName, mimeType, bucket = 'photos
   }
 }
 
-module.exports = { uploadToSupabase, detectKeyFormat };
+module.exports = { uploadToSupabase, detectKeyFormat, ensureBucket };

--- a/public/therapist-signup.html
+++ b/public/therapist-signup.html
@@ -62,7 +62,29 @@
     a.back { display: inline-block; margin-top: 22px; color: var(--muted); font-size: 13px; text-decoration: none; }
     a.back:hover { color: var(--ink); }
     @media (max-width: 560px) { .row, .row-3 { grid-template-columns: 1fr; } }
-  </style>
+
+    /* 收入與分潤 section */
+    .share { background: var(--cream-2); border: 1px solid var(--rule); border-radius: 10px; padding: 20px; margin-bottom: 22px; }
+    .share-head { margin-bottom: 14px; }
+    .share-title { font-size: 20px; font-weight: 400; margin: 4px 0 4px; letter-spacing: -0.01em; }
+    .share-title em { font-style: italic; color: var(--rose); }
+    .share-lede { color: var(--muted); font-size: 13px; margin: 0; }
+    .share-block { padding: 12px 0; border-top: 1px solid var(--rule); }
+    .share-block-title { font-size: 14px; font-weight: 600; color: var(--ink); margin-bottom: 4px; }
+    .share-block p { font-size: 13px; color: var(--ink-soft); margin: 4px 0; }
+    .share-block strong { color: var(--ink); font-weight: 600; }
+    .split-grid { display: grid; gap: 8px; margin: 10px 0 4px; }
+    .split-row { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 9px 12px; background: #fff; border: 1px solid var(--rule); border-radius: 8px; font-size: 13px; }
+    .split-row > span { color: var(--muted); }
+    .split-row.intro { border-color: var(--pink); background: #fdf4f3; }
+    .split-row.intro strong { color: var(--rose); }
+    .calc { margin-top: 12px; padding: 12px; background: #fff; border: 1px dashed var(--rule); border-radius: 8px; }
+    .calc-title { font-size: 12px; color: var(--ink-soft); font-weight: 600; margin-bottom: 8px; }
+    .calc-rows { display: grid; gap: 6px; }
+    .calc-item { display: flex; justify-content: space-between; align-items: baseline; font-size: 14px; }
+    .calc-item > span { color: var(--muted); font-size: 13px; }
+    .calc-item > b { color: var(--ink); font-variant-numeric: tabular-nums; }
+</style>
 </head>
 <body>
   <div class="wrap">
@@ -186,6 +208,42 @@
           <p class="note" id="docStatus" style="text-align:left; margin:8px 0 0;">諮商師證照、執業執照等。JPG / PNG / WebP / PDF，10MB 以內。文件僅供審核，不會公開。</p>
         </div>
 
+        <div class="field share">
+          <div class="share-head">
+            <span class="eyebrow">— 收入與分潤</span>
+            <h2 class="share-title">你會怎麼<em>賺取收入</em></h2>
+            <p class="share-lede">加入免費，平台只在你實際提供服務時收取分潤。以下是兩種收入方式。</p>
+          </div>
+
+          <div class="share-block">
+            <div class="share-block-title">💬 免費聊天</div>
+            <p>使用者可開啟你的聊天室，免費直接和你對談。聊得來時，系統會邀請對方預約付費視訊諮商。</p>
+          </div>
+
+          <div class="share-block">
+            <div class="share-block-title">🌱 公開問答分潤</div>
+            <p>經你和個案<strong>雙方同意</strong>後，對話可<strong>匿名</strong>公開為「公開問答」，幫助有相同困擾的人參考。</p>
+            <p>平台每月從營收提撥一筆「分潤金」，分給當月有參與的諮商師：<strong>初期平均分配</strong>，未來依參與度（回覆量、被公開、被標記有幫助）加權。每月結算後撥款。</p>
+          </div>
+
+          <div class="share-block">
+            <div class="share-block-title">🎥 視訊諮商抽成</div>
+            <p>1:1 視訊以 Zoom / Google Meet 進行（你接受預約後貼上會議連結）。款項由綠界（ECPay）線上收款，結算後撥付給你。</p>
+            <div class="split-grid">
+              <div class="split-row"><span>標準分潤</span><strong>平台 20%　·　你拿 80%</strong></div>
+              <div class="split-row intro"><span>新進優惠</span><strong>前 10 次完成預約，平台只收 10%　·　你拿 90%</strong></div>
+            </div>
+            <div class="calc" id="shareCalc">
+              <div class="calc-title">以你目前的費率試算每次視訊諮商實拿：</div>
+              <div class="calc-rows">
+                <div class="calc-item"><span>新進優惠（10%）</span><b id="calcIntro">—</b></div>
+                <div class="calc-item"><span>一般（20%）</span><b id="calcStd">—</b></div>
+              </div>
+              <p class="note" style="text-align:left; margin:8px 0 0;">實際撥款金額以平台每月結算為準。</p>
+            </div>
+          </div>
+        </div>
+
         <button type="submit" class="submit" id="submit">送出申請</button>
         <p class="note">送出後我們會在審核後與你聯繫。審核期間你的資料不會公開。</p>
       </form>
@@ -215,6 +273,23 @@
         .call(document.querySelectorAll('#' + id + ' input:checked'))
         .map(function (i) { return i.value; });
     }
+
+    // ── Live revenue-share calculator ───────────────────────────────────────
+    // Mirrors the 20% / 10%-intro split so the therapist sees their take-home
+    // for a video session as they set their rate.
+    function ntd(n) { return 'NT$' + Math.round(n).toLocaleString('en-US'); }
+    var rateField = document.querySelector('input[name="rateTwd"]');
+    var calcIntro = document.getElementById('calcIntro');
+    var calcStd = document.getElementById('calcStd');
+    function updateShareCalc() {
+      var rate = Number(rateField && rateField.value);
+      if (!rate || rate <= 0) { calcIntro.textContent = '—'; calcStd.textContent = '—'; return; }
+      // floor the platform fee, therapist keeps the remainder (matches backend).
+      calcIntro.textContent = ntd(rate - Math.floor(rate * 0.10)); // 90%
+      calcStd.textContent = ntd(rate - Math.floor(rate * 0.20));   // 80%
+    }
+    if (rateField) rateField.addEventListener('input', updateShareCalc);
+    updateShareCalc();
 
     var form = document.getElementById('form');
     var result = document.getElementById('result');

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -564,6 +564,8 @@ const ADMIN_HTML = `<!doctype html>
       <button class="tab" data-panel="pages">頁面</button>
       <button class="tab" data-panel="retention">回訪</button>
       <button class="tab" data-panel="therapists">諮商師</button>
+      <button class="tab" data-panel="reviews">評價</button>
+      <button class="tab" data-panel="pool">分潤</button>
     </div>
 
     <!-- Panel: Funnel (default) -->
@@ -654,6 +656,67 @@ const ADMIN_HTML = `<!doctype html>
           </thead>
           <tbody></tbody>
         </table>
+      </div>
+    </div>
+
+    <!-- Panel: Reviews (moderation) -->
+    <div class="panel" id="panel-reviews">
+      <p class="sub">客戶評價審核。通過後才會顯示在諮商師的公開檔案。</p>
+      <div class="controls">
+        <label>狀態
+          <select id="reviewStatus">
+            <option value="pending">待審核</option>
+            <option value="approved">已通過</option>
+            <option value="hidden">已隱藏</option>
+          </select>
+        </label>
+        <button id="reviewRefresh">重新整理</button>
+        <span class="muted" id="reviewStatusMsg"></span>
+      </div>
+      <div style="overflow-x:auto">
+        <table id="reviewsTable">
+          <thead>
+            <tr><th>諮商師</th><th>評價者</th><th class="num">評分</th><th>內容</th><th>時間</th><th>操作</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Panel: Q&A revenue pool -->
+    <div class="panel" id="panel-pool">
+      <p class="sub">每月問答分潤池。設定金額後計算各諮商師分潤，結算後逐一標記撥款（平台不會自動轉帳）。</p>
+      <div class="controls">
+        <label>月份 <input type="month" id="poolMonth"></label>
+        <label>金額 (NT$) <input type="number" id="poolAmount" min="0" step="1" style="width:120px"></label>
+        <label>分配方式
+          <select id="poolStrategy">
+            <option value="even">平均分配</option>
+            <option value="volume">依回覆量</option>
+            <option value="engagement">依參與度</option>
+          </select>
+        </label>
+        <button id="poolCreate">建立／更新</button>
+        <span class="muted" id="poolStatusMsg"></span>
+      </div>
+      <div style="overflow-x:auto">
+        <table id="poolsTable">
+          <thead>
+            <tr><th>月份</th><th class="num">金額</th><th>分配方式</th><th>狀態</th><th class="num">人數</th><th class="num">已分配</th><th>操作</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div id="poolDetail" hidden style="margin-top:20px">
+        <h3 style="margin:0 0 8px;font-weight:500;font-size:14px" id="poolDetailTitle">分潤明細</h3>
+        <div style="overflow-x:auto">
+          <table id="sharesTable">
+            <thead>
+              <tr><th>諮商師</th><th class="num">回覆</th><th class="num">公開</th><th class="num">讚</th><th class="num">權重</th><th class="num">分潤</th><th>撥款</th><th>操作</th></tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>
@@ -1010,6 +1073,172 @@ const ADMIN_HTML = `<!doctype html>
           if (!therapistsLoaded) { therapistsLoaded = true; loadTherapists(); }
         });
       }
+    });
+
+    // ── Reviews moderation ─────────────────────────────────────────────────
+    async function loadReviews() {
+      var status = $('reviewStatus').value;
+      $('reviewStatusMsg').textContent = '載入中…';
+      try {
+        var res = await fetch('/api/admin/therapists/reviews?status=' + encodeURIComponent(status));
+        if (!res.ok) throw new Error('reviews ' + res.status);
+        var body = await res.json();
+        renderReviews(body.reviews || [], status);
+        $('reviewStatusMsg').textContent = '更新於 ' + new Date().toLocaleTimeString('zh-TW');
+      } catch (e) { $('reviewStatusMsg').textContent = '載入失敗: ' + e.message; }
+    }
+    function renderReviews(rows, status) {
+      var tbody = document.querySelector('#reviewsTable tbody');
+      if (rows.length === 0) { tbody.innerHTML = '<tr><td colspan="6" class="muted">沒有資料</td></tr>'; return; }
+      tbody.innerHTML = rows.map(function (r) {
+        var actions = status === 'approved'
+          ? '<button data-rev="hide" data-id="' + r.id + '">隱藏</button>'
+          : '<button data-rev="approve" data-id="' + r.id + '">通過</button>' +
+            (status === 'pending' ? ' <button data-rev="hide" data-id="' + r.id + '">隱藏</button>' : '');
+        return '<tr>' +
+          '<td>' + esc(r.therapist_name) + '</td>' +
+          '<td>' + esc(r.reviewer_display) + '</td>' +
+          '<td class="num">' + (r.rating != null ? r.rating + ' ★' : '—') + '</td>' +
+          '<td style="max-width:340px">' + esc(r.body) + '</td>' +
+          '<td>' + fmtDate(r.created_at) + '</td>' +
+          '<td>' + actions + '</td>' +
+          '</tr>';
+      }).join('');
+      tbody.querySelectorAll('button[data-rev]').forEach(function (btn) {
+        btn.addEventListener('click', function () { moderateReview(btn.getAttribute('data-id'), btn.getAttribute('data-rev'), btn); });
+      });
+    }
+    async function moderateReview(id, action, btn) {
+      btn.disabled = true;
+      try {
+        var res = await fetch('/api/admin/therapists/reviews/' + id + '/moderate', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: action })
+        });
+        if (!res.ok) throw new Error('moderate ' + res.status);
+        await loadReviews();
+      } catch (e) { btn.disabled = false; $('reviewStatusMsg').textContent = '操作失敗: ' + e.message; }
+    }
+    $('reviewRefresh').addEventListener('click', loadReviews);
+    $('reviewStatus').addEventListener('change', loadReviews);
+
+    // ── Q&A revenue pool ───────────────────────────────────────────────────
+    var POOL_STRATEGY = { even: '平均分配', volume: '依回覆量', engagement: '依參與度' };
+    var POOL_STATUS = { draft: '草稿', computed: '已計算', finalized: '已結算', paid_out: '已撥款' };
+    async function loadPools() {
+      $('poolStatusMsg').textContent = '載入中…';
+      try {
+        var res = await fetch('/api/admin/therapists/qa/pools');
+        if (!res.ok) throw new Error('pools ' + res.status);
+        var body = await res.json();
+        renderPools(body.pools || []);
+        $('poolStatusMsg').textContent = '更新於 ' + new Date().toLocaleTimeString('zh-TW');
+      } catch (e) { $('poolStatusMsg').textContent = '載入失敗: ' + e.message; }
+    }
+    function renderPools(rows) {
+      var tbody = document.querySelector('#poolsTable tbody');
+      if (rows.length === 0) { tbody.innerHTML = '<tr><td colspan="7" class="muted">尚無分潤池</td></tr>'; return; }
+      tbody.innerHTML = rows.map(function (p) {
+        var month = String(p.period_month).slice(0, 7);
+        var actions = '<button data-pool="view" data-id="' + p.id + '">查看</button>';
+        if (p.status === 'draft' || p.status === 'computed') actions += ' <button data-pool="compute" data-id="' + p.id + '">計算</button>';
+        if (p.status === 'computed') actions += ' <button data-pool="finalize" data-id="' + p.id + '">結算</button>';
+        return '<tr>' +
+          '<td>' + esc(month) + '</td>' +
+          '<td class="num">NT$' + (p.pool_twd || 0).toLocaleString() + '</td>' +
+          '<td>' + esc(POOL_STRATEGY[p.split_strategy] || p.split_strategy) + '</td>' +
+          '<td>' + esc(POOL_STATUS[p.status] || p.status) + '</td>' +
+          '<td class="num">' + (p.recipient_count || 0) + '</td>' +
+          '<td class="num">NT$' + Number(p.allocated_twd || 0).toLocaleString() + '</td>' +
+          '<td>' + actions + '</td>' +
+          '</tr>';
+      }).join('');
+      tbody.querySelectorAll('button[data-pool]').forEach(function (btn) {
+        btn.addEventListener('click', function () { poolAction(btn.getAttribute('data-id'), btn.getAttribute('data-pool'), btn); });
+      });
+    }
+    async function poolAction(id, action, btn) {
+      if (action === 'view') return openPoolDetail(id);
+      btn.disabled = true;
+      try {
+        var path = action === 'compute' ? '/compute' : '/finalize';
+        var res = await fetch('/api/admin/therapists/qa/pools/' + id + path, { method: 'POST' });
+        if (!res.ok) throw new Error(action + ' ' + res.status);
+        await loadPools();
+        if (action === 'compute') openPoolDetail(id);
+      } catch (e) { btn.disabled = false; $('poolStatusMsg').textContent = '操作失敗: ' + e.message; }
+    }
+    var currentPoolId = null;
+    async function openPoolDetail(id) {
+      try {
+        currentPoolId = id;
+        var res = await fetch('/api/admin/therapists/qa/pools/' + id);
+        if (!res.ok) throw new Error('detail ' + res.status);
+        var body = await res.json();
+        $('poolDetail').hidden = false;
+        $('poolDetailTitle').textContent = '分潤明細 · ' + String(body.pool.period_month).slice(0, 7) + '（' + (POOL_STATUS[body.pool.status] || body.pool.status) + '）';
+        renderShares(body.shares || []);
+        $('poolDetail').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      } catch (e) { $('poolStatusMsg').textContent = '載入明細失敗: ' + e.message; }
+    }
+    function renderShares(rows) {
+      var tbody = document.querySelector('#sharesTable tbody');
+      if (rows.length === 0) { tbody.innerHTML = '<tr><td colspan="8" class="muted">尚未計算分潤</td></tr>'; return; }
+      tbody.innerHTML = rows.map(function (s) {
+        var paid = s.payout_status === 'paid'
+          ? '<span class="badge yes">已撥款</span>'
+          : '<span class="badge no">未撥款</span>';
+        var action = s.payout_status === 'paid' ? '—' : '<button data-share="' + s.id + '">標記已撥款</button>';
+        return '<tr>' +
+          '<td>' + esc(s.therapist_name) + '</td>' +
+          '<td class="num">' + (s.message_count || 0) + '</td>' +
+          '<td class="num">' + (s.published_count || 0) + '</td>' +
+          '<td class="num">' + (s.vote_count || 0) + '</td>' +
+          '<td class="num">' + Number(s.weight || 0) + '</td>' +
+          '<td class="num">NT$' + Number(s.share_twd || 0).toLocaleString() + '</td>' +
+          '<td>' + paid + '</td>' +
+          '<td>' + action + '</td>' +
+          '</tr>';
+      }).join('');
+      tbody.querySelectorAll('button[data-share]').forEach(function (btn) {
+        btn.addEventListener('click', function () { markSharePaid(btn.getAttribute('data-share'), btn); });
+      });
+    }
+    async function markSharePaid(id, btn) {
+      var note = window.prompt('撥款備註（選填，例如銀行匯款編號）：') || undefined;
+      btn.disabled = true;
+      try {
+        var res = await fetch('/api/admin/therapists/qa/shares/' + id + '/mark-paid', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ note: note })
+        });
+        if (!res.ok) throw new Error('mark-paid ' + res.status);
+        await loadPools();
+        if (currentPoolId) await openPoolDetail(currentPoolId);
+      } catch (e) { btn.disabled = false; $('poolStatusMsg').textContent = '撥款標記失敗: ' + e.message; }
+    }
+    async function createPool() {
+      var month = $('poolMonth').value; // YYYY-MM
+      var amount = parseInt($('poolAmount').value, 10);
+      if (!month || !(amount >= 0)) { $('poolStatusMsg').textContent = '請輸入月份與金額'; return; }
+      $('poolCreate').disabled = true;
+      try {
+        var res = await fetch('/api/admin/therapists/qa/pools', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ periodMonth: month + '-01', poolTwd: amount, splitStrategy: $('poolStrategy').value })
+        });
+        if (!res.ok) { var b = await res.json().catch(function(){return {};}); throw new Error(b.message || ('create ' + res.status)); }
+        await loadPools();
+        $('poolStatusMsg').textContent = '已建立／更新';
+      } catch (e) { $('poolStatusMsg').textContent = '建立失敗: ' + e.message; }
+      finally { $('poolCreate').disabled = false; }
+    }
+    $('poolCreate').addEventListener('click', createPool);
+
+    // Lazy-load the reviews + pool tabs the first time they're opened.
+    var reviewsLoaded = false, poolLoaded = false;
+    document.querySelectorAll('.tab').forEach(function (btn) {
+      var panel = btn.getAttribute('data-panel');
+      if (panel === 'reviews') btn.addEventListener('click', function () { if (!reviewsLoaded) { reviewsLoaded = true; loadReviews(); } });
+      if (panel === 'pool') btn.addEventListener('click', function () { if (!poolLoaded) { poolLoaded = true; loadPools(); } });
     });
 
     $('apply').addEventListener('click', load);

--- a/routes/therapists.js
+++ b/routes/therapists.js
@@ -21,10 +21,44 @@ const db = require('../database/db');
 const { authenticateToken, optionalAuth, generateToken } = require('../middleware/auth');
 const { uploadToSupabase } = require('../lib/supabase-storage');
 const emailService = require('../services/emailService');
+const ecpay = require('../lib/ecpay');
+const qaPool = require('../lib/qaPool');
 const { logInfo, logWarn, logError } = require('../lib/logger');
 
 const router = express.Router();
 const adminRouter = express.Router();
+
+// Paid video session economics. The platform keeps PLATFORM_FEE_RATE.standard
+// (20%) of each session, but only PLATFORM_FEE_RATE.intro (10%) for a new
+// therapist's first INTRO_SESSION_LIMIT completed sessions.
+const PLATFORM_FEE_RATE = { intro: 10, standard: 20 };
+const INTRO_SESSION_LIMIT = 10;
+const MEETING_PROVIDERS = ['zoom', 'meet', 'other'];
+
+// External origin ECPay can reach for callbacks (mirrors routes/billing.js).
+const appBaseUrl = () => (process.env.APP_BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
+
+// ECPay MerchantTradeNo: alphanumeric, <= 20 chars, unique (mirrors billing.js).
+const genMerchantTradeNo = () => {
+  const ts = Date.now().toString(36);
+  const rand = crypto.randomBytes(3).toString('hex');
+  return `TS${ts}${rand}`.slice(0, 20).toUpperCase();
+};
+
+// Compute the platform fee split for a therapist's next paid session. A session
+// counts toward the intro window only once it is paid AND completed, so we count
+// counts_toward_intro rows to decide the rate for the NEXT charge.
+const computeFeeSplit = async (therapistId, price) => {
+  const introUsed = await db.query(
+    `SELECT COUNT(*)::int AS c FROM therapist_consultations
+       WHERE therapist_id = $1 AND counts_toward_intro = true`,
+    [therapistId]
+  );
+  const feeRate = introUsed.rows[0].c < INTRO_SESSION_LIMIT ? PLATFORM_FEE_RATE.intro : PLATFORM_FEE_RATE.standard;
+  const platformFee = Math.floor((price * feeRate) / 100);
+  const therapistNet = price - platformFee;
+  return { feeRate, platformFee, therapistNet };
+};
 
 const FOCUS_AREAS = [
   'family',      // 家庭
@@ -59,6 +93,14 @@ const generateTempPassword = () => {
   return out;
 };
 
+// Parse a JSONB column that may come back as a JS array (node-postgres parses
+// jsonb) or, defensively, as a JSON string. Always returns an array.
+const asJsonArray = (value) => {
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') { try { const v = JSON.parse(value); return Array.isArray(v) ? v : []; } catch { return []; } }
+  return [];
+};
+
 // Shape the public-facing therapist object. Never leaks license_no /
 // contact_* — those are private to the applicant and admins.
 const toPublicTherapist = (row) => ({
@@ -74,6 +116,17 @@ const toPublicTherapist = (row) => ({
   rateTwd: row.rate_twd,
   sessionMinutes: row.session_minutes,
   identityStatus: row.identity_status,
+  // Rich profile sections (048).
+  introMessage: row.intro_message,
+  approach: row.approach,
+  about: row.about,
+  certifications: row.certifications || [],
+  currentPositions: row.current_positions || [],
+  qualifications: row.qualifications || [],
+  training: row.training || [],
+  publications: asJsonArray(row.publications),
+  articles: asJsonArray(row.articles),
+  acceptingNewClients: row.accepting_new_clients !== false,
   createdAt: row.created_at,
 });
 
@@ -109,6 +162,34 @@ const sanitizeCustomSpecialties = (value) => {
     .map((v) => (typeof v === 'string' ? v.trim().slice(0, MAX_CUSTOM_SPECIALTY_LEN) : ''))
     .filter(Boolean);
   return [...new Set(cleaned)].slice(0, MAX_CUSTOM_SPECIALTIES);
+};
+
+// Rich-profile list limits (positions / qualifications / training / certs).
+const MAX_PROFILE_LIST_ITEMS = 40;
+const MAX_PROFILE_LIST_ITEM_LEN = 300;
+// Generic line-list: trim, drop empties, clamp each line + the list length.
+const sanitizeTextList = (value) => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((v) => (typeof v === 'string' ? v.trim().slice(0, MAX_PROFILE_LIST_ITEM_LEN) : ''))
+    .filter(Boolean)
+    .slice(0, MAX_PROFILE_LIST_ITEMS);
+};
+// Link list (publications/articles): array of { title, source|url }. Keeps only
+// items with a non-empty title; clamps lengths; tolerates either key name.
+const sanitizeLinkList = (value, urlKey) => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const title = typeof item.title === 'string' ? item.title.trim().slice(0, MAX_PROFILE_LIST_ITEM_LEN) : '';
+      if (!title) return null;
+      const raw = item[urlKey] ?? item.url ?? item.source ?? '';
+      const link = typeof raw === 'string' ? raw.trim().slice(0, 1000) : '';
+      return { title, [urlKey]: link };
+    })
+    .filter(Boolean)
+    .slice(0, MAX_PROFILE_LIST_ITEMS);
 };
 
 // In-memory per-IP rate limit for the public (no-login) upload endpoints used
@@ -153,6 +234,16 @@ const documentUpload = multer({
   },
 });
 
+// Anonymise a reviewer's name for public display, like the reference site:
+// 林少湲 → 林O湲, 高媜 → 高O, 李 → 李. Masks the middle so a real name isn't
+// fully exposed on the public profile.
+const maskName = (name) => {
+  const n = (name || '').trim();
+  if (n.length <= 1) return n || '匿名';
+  if (n.length === 2) return `${n[0]}O`;
+  return `${n[0]}O${n[n.length - 1]}`;
+};
+
 const handleValidation = (req, res) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -170,6 +261,7 @@ const loadConsultationAccess = async (consultationId, userId) => {
   const result = await db.query(`
     SELECT
       tc.id, tc.therapist_id, tc.requester_id, tc.couple_id, tc.status,
+      tc.public_status, tc.public_title,
       t.user_id AS therapist_user_id, t.display_name AS therapist_name,
       c.user1_id, c.user2_id
     FROM therapist_consultations tc
@@ -368,6 +460,17 @@ router.put('/me', authenticateToken, [
   body('rateTwd').optional().isInt({ min: 0, max: 100000 }).withMessage('費率無效'),
   body('sessionMinutes').optional().isInt({ min: 10, max: 240 }).withMessage('時長無效'),
   body('contactPhone').optional({ nullable: true }).isString().isLength({ max: 40 }),
+  // Rich profile (048)
+  body('introMessage').optional({ nullable: true }).isString().isLength({ max: 8000 }),
+  body('approach').optional({ nullable: true }).isString().isLength({ max: 8000 }),
+  body('about').optional({ nullable: true }).isString().isLength({ max: 8000 }),
+  body('certifications').optional().isArray(),
+  body('currentPositions').optional().isArray(),
+  body('qualifications').optional().isArray(),
+  body('training').optional().isArray(),
+  body('publications').optional().isArray(),
+  body('articles').optional().isArray(),
+  body('acceptingNewClients').optional().isBoolean(),
 ], async (req, res) => {
   if (!handleValidation(req, res)) return;
   try {
@@ -399,6 +502,18 @@ router.put('/me', authenticateToken, [
     if (req.body.rateTwd !== undefined) push('rate_twd', req.body.rateTwd);
     if (req.body.sessionMinutes !== undefined) push('session_minutes', req.body.sessionMinutes);
     if (req.body.contactPhone !== undefined) push('contact_phone', req.body.contactPhone || null);
+
+    // Rich profile sections (048).
+    if (req.body.introMessage !== undefined) push('intro_message', (req.body.introMessage || '').trim() || null);
+    if (req.body.approach !== undefined) push('approach', (req.body.approach || '').trim() || null);
+    if (req.body.about !== undefined) push('about', (req.body.about || '').trim() || null);
+    if (req.body.certifications !== undefined) push('certifications', sanitizeTextList(req.body.certifications));
+    if (req.body.currentPositions !== undefined) push('current_positions', sanitizeTextList(req.body.currentPositions));
+    if (req.body.qualifications !== undefined) push('qualifications', sanitizeTextList(req.body.qualifications));
+    if (req.body.training !== undefined) push('training', sanitizeTextList(req.body.training));
+    if (req.body.publications !== undefined) push('publications', JSON.stringify(sanitizeLinkList(req.body.publications, 'source')));
+    if (req.body.articles !== undefined) push('articles', JSON.stringify(sanitizeLinkList(req.body.articles, 'url')));
+    if (req.body.acceptingNewClients !== undefined) push('accepting_new_clients', Boolean(req.body.acceptingNewClients));
 
     if (updates.length === 0) {
       return res.status(400).json({ success: false, error_code: 'NO_CHANGES', message: '沒有要更新的欄位' });
@@ -455,7 +570,11 @@ router.get('/consultations/mine', authenticateToken, async (req, res) => {
       SELECT
         tc.id, tc.focus_area, tc.message, tc.preferred_time, tc.status,
         tc.responded_at, tc.response_note, tc.created_at,
+        tc.public_status, tc.public_title,
+        tc.booking_type, tc.payment_status, tc.price_twd, tc.meeting_provider, tc.meeting_url,
+        tc.therapist_id,
         t.display_name AS therapist_name, t.title AS therapist_title,
+        t.rate_twd AS therapist_rate_twd, t.session_minutes AS therapist_session_minutes,
         t.user_id AS therapist_user_id,
         requester.nickname AS requester_name,
         (SELECT COUNT(*) FROM consultation_messages cm WHERE cm.consultation_id = tc.id) AS message_count
@@ -473,8 +592,11 @@ router.get('/consultations/mine', authenticateToken, async (req, res) => {
       success: true,
       consultations: result.rows.map((r) => ({
         id: r.id,
+        therapistId: r.therapist_id,
         therapistName: r.therapist_name,
         therapistTitle: r.therapist_title,
+        therapistRateTwd: r.therapist_rate_twd,
+        therapistSessionMinutes: r.therapist_session_minutes,
         requesterName: r.requester_name,
         role: r.therapist_user_id && r.therapist_user_id === req.user.id ? 'therapist' : 'client',
         focusArea: r.focus_area,
@@ -483,6 +605,14 @@ router.get('/consultations/mine', authenticateToken, async (req, res) => {
         status: r.status,
         respondedAt: r.responded_at,
         responseNote: r.response_note,
+        publicStatus: r.public_status,
+        publicTitle: r.public_title,
+        bookingType: r.booking_type,
+        paymentStatus: r.payment_status,
+        priceTwd: r.price_twd,
+        meetingProvider: r.meeting_provider,
+        // Only reveal the meeting link once paid (it's the therapist's room).
+        meetingUrl: r.payment_status === 'paid' ? r.meeting_url : null,
         messageCount: Number(r.message_count) || 0,
         createdAt: r.created_at,
       })),
@@ -518,6 +648,8 @@ router.get('/consultations/:id/messages', authenticateToken, async (req, res) =>
       role: access.role,
       therapistName: access.row.therapist_name,
       currentUserId: req.user.id,
+      publicStatus: access.row.public_status,
+      publicTitle: access.row.public_title,
       messages: msgs.rows.map((m) => ({
         id: m.id,
         senderId: m.sender_id,
@@ -578,7 +710,7 @@ router.post('/consultations/:id/messages', authenticateToken, [
 // POST /api/therapists/consultations/:id/respond — the therapist accepts /
 // declines / completes a consultation. Therapist (linked user) only.
 router.post('/consultations/:id/respond', authenticateToken, [
-  body('action').isIn(['accept', 'decline', 'complete']).withMessage('action 無效'),
+  body('action').isIn(['accept', 'decline', 'complete', 'no_show']).withMessage('action 無效'),
   body('note').optional({ nullable: true }).isString().isLength({ max: 1000 }),
 ], async (req, res) => {
   if (!handleValidation(req, res)) return;
@@ -587,18 +719,157 @@ router.post('/consultations/:id/respond', authenticateToken, [
     if (!access) return res.status(404).json({ success: false, message: '找不到這個預約' });
     if (!access.isTherapist) return res.status(403).json({ success: false, message: '只有諮商師可以回覆預約' });
 
-    const statusMap = { accept: 'accepted', decline: 'declined', complete: 'completed' };
+    const statusMap = { accept: 'accepted', decline: 'declined', complete: 'completed', no_show: 'no_show' };
     const status = statusMap[req.body.action];
+    // A session counts toward the therapist's intro window only when it is both
+    // paid AND completed — flip the flag here (guarded by payment_status in SQL).
+    const willComplete = req.body.action === 'complete';
     const result = await db.query(
       `UPDATE therapist_consultations
-          SET status = $1, response_note = $2, responded_at = NOW()
-        WHERE id = $3 RETURNING id, status`,
-      [status, req.body.note || null, req.params.id]
+          SET status = $1, response_note = $2, responded_at = NOW(),
+              counts_toward_intro = CASE WHEN $4 AND payment_status = 'paid' THEN true ELSE counts_toward_intro END
+        WHERE id = $3 RETURNING id, status, counts_toward_intro`,
+      [status, req.body.note || null, req.params.id, willComplete]
     );
     res.json({ success: true, consultation: result.rows[0] });
   } catch (error) {
     logError('Failed to respond to consultation', { id: req.params.id, err: error.message });
     res.status(500).json({ success: false, message: '回覆預約失敗' });
+  }
+});
+
+// --- 公開問答 (Public Q&A) publish handshake ----------------------------
+//
+// A free consultation chat can be published, read-only and anonymised, so other
+// users can learn from it. Publishing needs BOTH parties to consent: one side
+// proposes (publish-request), the OTHER role approves (publish-approve), and
+// either side can pull it back (publish-withdraw). The asker is never named in
+// the public payload — anonymisation is enforced in the browse routes below.
+
+const MAX_PUBLIC_TITLE_LEN = 200;
+
+// POST /api/therapists/consultations/:id/publish-request — propose publishing.
+// Either participant may propose; records which role asked so the other role's
+// approval is what flips it public.
+router.post('/consultations/:id/publish-request', authenticateToken, [
+  body('title').isString().trim().isLength({ min: 1, max: MAX_PUBLIC_TITLE_LEN })
+    .withMessage(`標題長度需為 1-${MAX_PUBLIC_TITLE_LEN} 字`),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個諮商室' });
+    if (!access.isParticipant) return res.status(403).json({ success: false, message: '你沒有權限公開這個對話' });
+
+    // Only propose from a private/withdrawn room. Re-proposing a pending request
+    // or an already-published room is a no-op the UI should already prevent.
+    if (!['private', 'withdrawn'].includes(access.row.public_status)) {
+      return res.status(409).json({
+        success: false,
+        error_code: 'PUBLISH_ALREADY_PENDING',
+        message: access.row.public_status === 'published'
+          ? '這個對話已經公開了'
+          : '已經有一方提議公開，等待另一方同意中',
+      });
+    }
+
+    const nextStatus = access.isTherapist ? 'therapist_requested' : 'client_requested';
+    const result = await db.query(`
+      UPDATE therapist_consultations
+         SET public_status = $1, public_requested_by = $2, public_title = $3,
+             public_approved_by = NULL, published_at = NULL
+       WHERE id = $4
+       RETURNING id, public_status, public_title
+    `, [nextStatus, req.user.id, req.body.title.trim(), req.params.id]);
+
+    logInfo('Public Q&A publish requested', {
+      consultationId: req.params.id, userId: req.user.id, role: access.role,
+    });
+    res.json({
+      success: true,
+      message: access.isTherapist
+        ? '已提議公開，等待個案同意。同意後會匿名顯示在公開問答。'
+        : '已提議公開，等待諮商師同意。同意後會匿名顯示在公開問答。',
+      publicStatus: result.rows[0].public_status,
+      publicTitle: result.rows[0].public_title,
+    });
+  } catch (error) {
+    logError('Failed to request publish', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '提議公開失敗，請稍後再試' });
+  }
+});
+
+// POST /api/therapists/consultations/:id/publish-approve — the OTHER party
+// consents, flipping the room to published.
+router.post('/consultations/:id/publish-approve', authenticateToken, async (req, res) => {
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個諮商室' });
+    if (!access.isParticipant) return res.status(403).json({ success: false, message: '你沒有權限公開這個對話' });
+
+    const status = access.row.public_status;
+    if (!['client_requested', 'therapist_requested'].includes(status)) {
+      return res.status(409).json({
+        success: false,
+        error_code: 'PUBLISH_NOT_PENDING',
+        message: status === 'published' ? '這個對話已經公開了' : '目前沒有待同意的公開提議',
+      });
+    }
+    // Consent must come from the opposite role to whoever proposed it.
+    const approverMustBeTherapist = status === 'client_requested';
+    if (approverMustBeTherapist !== access.isTherapist) {
+      return res.status(403).json({
+        success: false,
+        error_code: 'PUBLISH_NEEDS_OTHER_PARTY',
+        message: approverMustBeTherapist
+          ? '需要由諮商師同意才能公開'
+          : '需要由個案同意才能公開',
+      });
+    }
+
+    const result = await db.query(`
+      UPDATE therapist_consultations
+         SET public_status = 'published', public_approved_by = $1, published_at = NOW()
+       WHERE id = $2
+       RETURNING id, public_status, published_at
+    `, [req.user.id, req.params.id]);
+
+    logInfo('Public Q&A published', { consultationId: req.params.id, userId: req.user.id });
+    res.json({
+      success: true,
+      message: '對話已匿名公開為公開問答，謝謝你願意幫助其他人。',
+      publicStatus: result.rows[0].public_status,
+      publishedAt: result.rows[0].published_at,
+    });
+  } catch (error) {
+    logError('Failed to approve publish', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '同意公開失敗，請稍後再試' });
+  }
+});
+
+// POST /api/therapists/consultations/:id/publish-withdraw — either party pulls a
+// pending proposal or a published thread back to private.
+router.post('/consultations/:id/publish-withdraw', authenticateToken, async (req, res) => {
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個諮商室' });
+    if (!access.isParticipant) return res.status(403).json({ success: false, message: '你沒有權限變更這個對話' });
+
+    if (access.row.public_status === 'private') {
+      return res.json({ success: true, message: '這個對話本來就是私密的', publicStatus: 'private' });
+    }
+    const result = await db.query(`
+      UPDATE therapist_consultations
+         SET public_status = 'withdrawn', published_at = NULL
+       WHERE id = $1
+       RETURNING id, public_status
+    `, [req.params.id]);
+
+    logInfo('Public Q&A withdrawn', { consultationId: req.params.id, userId: req.user.id });
+    res.json({ success: true, message: '已取消公開，這個對話不再顯示於公開問答。', publicStatus: result.rows[0].public_status });
+  } catch (error) {
+    logError('Failed to withdraw publish', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '取消公開失敗，請稍後再試' });
   }
 });
 
@@ -625,6 +896,186 @@ router.get('/applications/mine', authenticateToken, async (req, res) => {
   } catch (error) {
     logError('Failed to list my applications', { userId: req.user?.id, err: error.message });
     res.status(500).json({ success: false, message: '無法取得申請紀錄' });
+  }
+});
+
+// --- 公開問答 (Public Q&A) read-only browse -----------------------------
+//
+// Defined before /:id so "qa" isn't captured as a therapist id. These serve the
+// published consultations to everyone (optionalAuth). The asker is ALWAYS
+// anonymised here ("匿名個案") and their sender_id/name/email are never sent; the
+// therapist is shown because the thread showcases their work.
+
+const PUBLIC_QA_PAGE_SIZE = 20;
+const QA_PREVIEW_LEN = 140;
+
+// GET /api/therapists/qa?focus=couple&page=1 — list published threads.
+router.get('/qa', optionalAuth, [
+  queryValidator('focus').optional().isIn(FOCUS_AREAS).withMessage('focus 無效'),
+  queryValidator('page').optional().isInt({ min: 1 }).withMessage('page 無效'),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const page = Math.max(1, Number(req.query.page) || 1);
+    const offset = (page - 1) * PUBLIC_QA_PAGE_SIZE;
+    const params = [];
+    let where = `tc.public_status = 'published'`;
+    if (req.query.focus) {
+      params.push(req.query.focus);
+      where += ` AND tc.focus_area = $${params.length}`;
+    }
+    params.push(PUBLIC_QA_PAGE_SIZE + 1, offset); // fetch one extra to detect "hasMore"
+    const result = await db.query(`
+      SELECT tc.id, tc.public_title, tc.focus_area, tc.published_at,
+             t.id AS therapist_id, t.display_name AS therapist_name,
+             t.title AS therapist_title, t.photo_url,
+             (SELECT COUNT(*) FROM consultation_messages cm WHERE cm.consultation_id = tc.id) AS message_count,
+             (SELECT COUNT(*) FROM consultation_public_votes v WHERE v.consultation_id = tc.id) AS helpful_count,
+             (SELECT cm.body FROM consultation_messages cm
+               WHERE cm.consultation_id = tc.id ORDER BY cm.created_at ASC LIMIT 1) AS first_message
+        FROM therapist_consultations tc
+        JOIN therapists t ON t.id = tc.therapist_id
+       WHERE ${where}
+       ORDER BY tc.published_at DESC
+       LIMIT $${params.length - 1} OFFSET $${params.length}
+    `, params);
+
+    const rows = result.rows.slice(0, PUBLIC_QA_PAGE_SIZE);
+    const hasMore = result.rows.length > PUBLIC_QA_PAGE_SIZE;
+    res.json({
+      success: true,
+      page,
+      hasMore,
+      threads: rows.map((r) => ({
+        id: r.id,
+        title: r.public_title,
+        focusArea: r.focus_area,
+        publishedAt: r.published_at,
+        therapist: {
+          id: r.therapist_id,
+          displayName: r.therapist_name,
+          title: r.therapist_title,
+          photoUrl: r.photo_url,
+        },
+        preview: r.first_message
+          ? r.first_message.slice(0, QA_PREVIEW_LEN) + (r.first_message.length > QA_PREVIEW_LEN ? '…' : '')
+          : '',
+        messageCount: Number(r.message_count) || 0,
+        helpfulCount: Number(r.helpful_count) || 0,
+      })),
+    });
+  } catch (error) {
+    logError('Failed to list public Q&A', { err: error.message });
+    res.status(500).json({ success: false, message: '無法取得公開問答列表' });
+  }
+});
+
+// GET /api/therapists/qa/:id — a single published thread, read-only + anonymised.
+router.get('/qa/:id', optionalAuth, async (req, res) => {
+  try {
+    const meta = await db.query(`
+      SELECT tc.id, tc.public_title, tc.focus_area, tc.published_at,
+             t.id AS therapist_id, t.user_id AS therapist_user_id,
+             t.display_name AS therapist_name, t.title AS therapist_title, t.photo_url,
+             (SELECT COUNT(*) FROM consultation_public_votes v WHERE v.consultation_id = tc.id) AS helpful_count
+        FROM therapist_consultations tc
+        JOIN therapists t ON t.id = tc.therapist_id
+       WHERE tc.id = $1 AND tc.public_status = 'published'
+    `, [req.params.id]);
+    if (meta.rows.length === 0) {
+      return res.status(404).json({ success: false, message: '找不到這則公開問答，或它已被取消公開' });
+    }
+    const m = meta.rows[0];
+
+    const msgs = await db.query(`
+      SELECT cm.id, cm.sender_id, cm.body, cm.created_at
+        FROM consultation_messages cm
+       WHERE cm.consultation_id = $1
+       ORDER BY cm.created_at ASC
+    `, [req.params.id]);
+
+    let hasVoted = false;
+    if (req.user) {
+      const v = await db.query(
+        `SELECT 1 FROM consultation_public_votes WHERE consultation_id = $1 AND voter_id = $2`,
+        [req.params.id, req.user.id]
+      );
+      hasVoted = v.rows.length > 0;
+    }
+
+    res.json({
+      success: true,
+      thread: {
+        id: m.id,
+        title: m.public_title,
+        focusArea: m.focus_area,
+        publishedAt: m.published_at,
+        helpfulCount: Number(m.helpful_count) || 0,
+        hasVoted,
+        therapist: {
+          id: m.therapist_id,
+          displayName: m.therapist_name,
+          title: m.therapist_title,
+          photoUrl: m.photo_url,
+        },
+        // Anonymised transcript: never leak the asker's id/name. Only the
+        // therapist is identified; everyone else is "匿名個案".
+        messages: msgs.rows.map((msg) => {
+          const isTherapist = Boolean(m.therapist_user_id) && msg.sender_id === m.therapist_user_id;
+          return {
+            id: msg.id,
+            body: msg.body,
+            createdAt: msg.created_at,
+            isTherapist,
+            senderName: isTherapist ? m.therapist_name : '匿名個案',
+          };
+        }),
+      },
+    });
+  } catch (error) {
+    logError('Failed to load public Q&A thread', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法載入公開問答' });
+  }
+});
+
+// POST /api/therapists/qa/:id/vote — toggle a "helpful" vote on a published
+// thread. Idempotent per (thread, user); returns the new state + count.
+router.post('/qa/:id/vote', authenticateToken, async (req, res) => {
+  try {
+    const pub = await db.query(
+      `SELECT 1 FROM therapist_consultations WHERE id = $1 AND public_status = 'published'`,
+      [req.params.id]
+    );
+    if (pub.rows.length === 0) {
+      return res.status(404).json({ success: false, message: '找不到這則公開問答' });
+    }
+    const existing = await db.query(
+      `SELECT 1 FROM consultation_public_votes WHERE consultation_id = $1 AND voter_id = $2`,
+      [req.params.id, req.user.id]
+    );
+    let voted;
+    if (existing.rows.length > 0) {
+      await db.query(
+        `DELETE FROM consultation_public_votes WHERE consultation_id = $1 AND voter_id = $2`,
+        [req.params.id, req.user.id]
+      );
+      voted = false;
+    } else {
+      await db.query(
+        `INSERT INTO consultation_public_votes (consultation_id, voter_id)
+         VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+        [req.params.id, req.user.id]
+      );
+      voted = true;
+    }
+    const count = await db.query(
+      `SELECT COUNT(*)::int AS c FROM consultation_public_votes WHERE consultation_id = $1`,
+      [req.params.id]
+    );
+    res.json({ success: true, voted, helpfulCount: count.rows[0].c });
+  } catch (error) {
+    logError('Failed to vote public Q&A', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '操作失敗，請稍後再試' });
   }
 });
 
@@ -850,6 +1301,388 @@ router.post('/:id/consult', authenticateToken, [
   }
 });
 
+// --- Paid video sessions (視訊諮商) -------------------------------------
+
+// POST /api/therapists/:id/book-video — book a paid 1:1 video session. Snapshots
+// the therapist's price + duration; lands as pending/unpaid. sourceConsultationId
+// links it back to the free chat it grew out of (the "預約視訊諮商" nudge).
+router.post('/:id/book-video', authenticateToken, [
+  body('message').optional({ nullable: true }).isString().isLength({ max: 2000 }),
+  body('preferredTime').optional({ nullable: true }).isISO8601().withMessage('時間格式錯誤'),
+  body('sourceConsultationId').optional({ nullable: true }).isUUID().withMessage('來源無效'),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const therapistId = req.params.id;
+    const therapist = await db.query(
+      `SELECT id, rate_twd, session_minutes, accepting_new_clients FROM therapists WHERE id = $1 AND status = 'approved'`,
+      [therapistId]
+    );
+    if (therapist.rows.length === 0) {
+      return res.status(404).json({ success: false, message: '找不到這位諮商師' });
+    }
+    const t = therapist.rows[0];
+    if (t.accepting_new_clients === false) {
+      return res.status(409).json({ success: false, error_code: 'NOT_ACCEPTING', message: '這位諮商師目前暫不開放新案預約' });
+    }
+
+    const couple = await db.query(
+      `SELECT id FROM couples WHERE user1_id = $1 OR user2_id = $1 LIMIT 1`,
+      [req.user.id]
+    );
+    const coupleId = couple.rows[0] ? couple.rows[0].id : null;
+
+    const result = await db.query(`
+      INSERT INTO therapist_consultations
+        (therapist_id, requester_id, couple_id, message, preferred_time,
+         booking_type, source_consultation_id, duration_minutes, price_twd, payment_status)
+      VALUES ($1,$2,$3,$4,$5,'scheduled',$6,$7,$8,'unpaid')
+      RETURNING id, status, payment_status, created_at
+    `, [
+      therapistId, req.user.id, coupleId, req.body.message || null,
+      req.body.preferredTime || null, req.body.sourceConsultationId || null,
+      t.session_minutes, t.rate_twd,
+    ]);
+
+    logInfo('Video session booked', { userId: req.user.id, therapistId, consultationId: result.rows[0].id });
+    res.status(201).json({
+      success: true,
+      message: '已建立預約，請完成付款以確認時段。',
+      consultation: { id: result.rows[0].id, status: result.rows[0].status, paymentStatus: result.rows[0].payment_status, priceTwd: t.rate_twd },
+    });
+  } catch (error) {
+    logError('Failed to book video session', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '預約失敗，請稍後再試' });
+  }
+});
+
+// POST /api/therapists/consultations/:id/meeting-link — therapist pastes the
+// third-party video link. Allowed once the booking is accepted.
+router.post('/consultations/:id/meeting-link', authenticateToken, [
+  body('provider').isIn(MEETING_PROVIDERS).withMessage('provider 無效'),
+  body('url').isString().trim().isURL({ require_protocol: true }).withMessage('請貼上有效的會議連結'),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個預約' });
+    if (!access.isTherapist) return res.status(403).json({ success: false, message: '只有諮商師可以設定會議連結' });
+    if (access.row.status !== 'accepted') {
+      return res.status(409).json({ success: false, error_code: 'NOT_ACCEPTED', message: '請先接受預約，再設定會議連結' });
+    }
+    const result = await db.query(`
+      UPDATE therapist_consultations
+         SET meeting_provider = $1, meeting_url = $2, meeting_set_at = NOW()
+       WHERE id = $3 RETURNING id, meeting_provider, meeting_url
+    `, [req.body.provider, req.body.url.trim(), req.params.id]);
+    logInfo('Meeting link set', { consultationId: req.params.id, userId: req.user.id });
+    res.json({ success: true, message: '會議連結已提供給對方。', meetingProvider: result.rows[0].meeting_provider, meetingUrl: result.rows[0].meeting_url });
+  } catch (error) {
+    logError('Failed to set meeting link', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '設定會議連結失敗，請稍後再試' });
+  }
+});
+
+// POST /api/therapists/consultations/:id/pay — start ECPay checkout for a
+// scheduled session. Computes + snapshots the fee split, creates a pending
+// order, and returns the form params the frontend auto-submits.
+router.post('/consultations/:id/pay', authenticateToken, async (req, res) => {
+  try {
+    const access = await loadConsultationAccess(req.params.id, req.user.id);
+    if (!access) return res.status(404).json({ success: false, message: '找不到這個預約' });
+    if (!access.isParticipant || access.isTherapist) {
+      return res.status(403).json({ success: false, message: '只有預約方可以付款' });
+    }
+
+    const row = await db.query(
+      `SELECT tc.id, tc.therapist_id, tc.booking_type, tc.price_twd, tc.payment_status,
+              t.display_name AS therapist_name
+         FROM therapist_consultations tc JOIN therapists t ON t.id = tc.therapist_id
+        WHERE tc.id = $1`,
+      [req.params.id]
+    );
+    const c = row.rows[0];
+    if (c.booking_type !== 'scheduled') {
+      return res.status(400).json({ success: false, error_code: 'NOT_SCHEDULED', message: '這不是付費視訊預約' });
+    }
+    if (c.payment_status === 'paid') {
+      return res.status(409).json({ success: false, error_code: 'ALREADY_PAID', message: '這個預約已經付款了' });
+    }
+    const price = Number(c.price_twd) || 0;
+    if (price <= 0) {
+      return res.status(400).json({ success: false, error_code: 'INVALID_PRICE', message: '預約金額異常，請重新預約' });
+    }
+
+    const { feeRate, platformFee, therapistNet } = await computeFeeSplit(c.therapist_id, price);
+    const merchantTradeNo = genMerchantTradeNo();
+
+    await db.transaction(async (client) => {
+      await client.query(`
+        INSERT INTO session_payment_orders
+          (consultation_id, payer_id, therapist_id, merchant_trade_no, amount,
+           fee_rate, platform_fee, therapist_net, status)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'pending')
+      `, [c.id, req.user.id, c.therapist_id, merchantTradeNo, price, feeRate, platformFee, therapistNet]);
+      await client.query(`
+        UPDATE therapist_consultations
+           SET payment_status = 'pending', fee_rate = $2, platform_fee_twd = $3, therapist_net_twd = $4
+         WHERE id = $1
+      `, [c.id, feeRate, platformFee, therapistNet]);
+    });
+
+    const base = appBaseUrl();
+    const { actionUrl, params } = ecpay.buildCheckoutParams({
+      merchantTradeNo,
+      amount: price,
+      itemName: `視訊諮商 — ${c.therapist_name}`.slice(0, 200),
+      tradeDesc: 'Twogether 視訊諮商',
+      returnUrl: `${base}/api/therapists/sessions/ecpay/callback`,
+      orderResultUrl: `${base}/api/therapists/sessions/ecpay/return`,
+      clientBackUrl: `${base}/booking/result`,
+    });
+
+    logInfo('Session checkout created', { consultationId: c.id, userId: req.user.id, merchantTradeNo, amount: price, feeRate });
+    res.json({ success: true, action_url: actionUrl, params });
+  } catch (error) {
+    logError('Failed to start session payment', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法建立付款，請稍後再試' });
+  }
+});
+
+// POST /api/therapists/sessions/ecpay/callback — ECPay server-to-server callback
+// (PUBLIC, no JWT). Authoritative paid mark + fee-split record. Idempotent.
+router.post('/sessions/ecpay/callback', async (req, res) => {
+  const payload = req.body || {};
+  try {
+    if (!ecpay.verifyCallback(payload)) {
+      logWarn('session.callback.bad_mac', { merchantTradeNo: payload.MerchantTradeNo });
+      return res.status(400).send('0|CheckMacValue Error');
+    }
+    const merchantTradeNo = payload.MerchantTradeNo;
+    const rtnCode = String(payload.RtnCode);
+
+    const orderRes = await db.query(`SELECT * FROM session_payment_orders WHERE merchant_trade_no = $1`, [merchantTradeNo]);
+    const order = orderRes.rows[0];
+    if (!order) {
+      logWarn('session.callback.unknown_order', { merchantTradeNo });
+      return res.send('1|OK');
+    }
+    if (order.status === 'paid') return res.send('1|OK'); // idempotent
+
+    if (Number(payload.TradeAmt) !== Number(order.amount)) {
+      logWarn('session.callback.amount_mismatch', { merchantTradeNo, expected: order.amount, got: payload.TradeAmt });
+      return res.status(400).send('0|Amount Mismatch');
+    }
+
+    if (rtnCode !== '1') {
+      await db.transaction(async (client) => {
+        await client.query(`UPDATE session_payment_orders SET status = 'failed', raw_callback = $2 WHERE id = $1`, [order.id, payload]);
+        await client.query(`UPDATE therapist_consultations SET payment_status = 'failed' WHERE id = $1`, [order.consultation_id]);
+      });
+      logInfo('session.callback.failed', { merchantTradeNo, rtnCode, msg: payload.RtnMsg });
+      return res.send('1|OK');
+    }
+
+    await db.transaction(async (client) => {
+      await client.query(`
+        UPDATE session_payment_orders
+           SET status = 'paid', paid_at = NOW(), ecpay_trade_no = $2, payment_method = $3, raw_callback = $4
+         WHERE id = $1
+      `, [order.id, payload.TradeNo || null, payload.PaymentType || null, payload]);
+      await client.query(`
+        UPDATE therapist_consultations
+           SET payment_status = 'paid', paid_at = NOW(),
+               price_twd = $2, fee_rate = $3, platform_fee_twd = $4, therapist_net_twd = $5
+         WHERE id = $1
+      `, [order.consultation_id, order.amount, order.fee_rate, order.platform_fee, order.therapist_net]);
+    });
+
+    logInfo('session.callback.paid', { merchantTradeNo, consultationId: order.consultation_id, therapistNet: order.therapist_net });
+    res.send('1|OK');
+  } catch (error) {
+    logError('Session callback failed', { err: error.message });
+    res.status(500).send('0|Error');
+  }
+});
+
+// POST /api/therapists/sessions/ecpay/return — browser POST-back (PUBLIC). The
+// grant already happened server-side; just 302 to the SPA result route.
+router.post('/sessions/ecpay/return', (req, res) => {
+  const ok = String(req.body?.RtnCode) === '1';
+  res.redirect(302, `/booking/result?status=${ok ? 'success' : 'failed'}`);
+});
+
+// GET /api/therapists/me/earnings — therapist's session earnings + intro status.
+router.get('/me/earnings', authenticateToken, async (req, res) => {
+  try {
+    const t = await db.query(`SELECT id FROM therapists WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1`, [req.user.id]);
+    if (t.rows.length === 0) {
+      return res.status(404).json({ success: false, error_code: 'NO_THERAPIST_PROFILE', message: '你還沒有諮商師檔案' });
+    }
+    const therapistId = t.rows[0].id;
+
+    const introUsed = await db.query(
+      `SELECT COUNT(*)::int AS c FROM therapist_consultations WHERE therapist_id = $1 AND counts_toward_intro = true`,
+      [therapistId]
+    );
+    const introCount = introUsed.rows[0].c;
+    const paid = await db.query(`
+      SELECT tc.id, tc.price_twd, tc.fee_rate, tc.platform_fee_twd, tc.therapist_net_twd,
+             tc.paid_at, tc.status, tc.scheduled_at, tc.preferred_time
+        FROM therapist_consultations tc
+       WHERE tc.therapist_id = $1 AND tc.payment_status = 'paid'
+       ORDER BY tc.paid_at DESC NULLS LAST
+    `, [therapistId]);
+    const totalNet = paid.rows.reduce((sum, r) => sum + (Number(r.therapist_net_twd) || 0), 0);
+
+    res.json({
+      success: true,
+      earnings: {
+        introSessionsUsed: introCount,
+        introSessionsRemaining: Math.max(0, INTRO_SESSION_LIMIT - introCount),
+        currentFeeRate: introCount < INTRO_SESSION_LIMIT ? PLATFORM_FEE_RATE.intro : PLATFORM_FEE_RATE.standard,
+        paidSessionCount: paid.rows.length,
+        totalNetTwd: totalNet,
+        sessions: paid.rows.map((r) => ({
+          id: r.id,
+          priceTwd: r.price_twd,
+          feeRate: r.fee_rate,
+          platformFeeTwd: r.platform_fee_twd,
+          therapistNetTwd: r.therapist_net_twd,
+          paidAt: r.paid_at,
+          status: r.status,
+        })),
+      },
+    });
+  } catch (error) {
+    logError('Failed to load earnings', { userId: req.user?.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法取得收入資料' });
+  }
+});
+
+// --- Client reviews (客戶評價) ------------------------------------------
+
+// GET /api/therapists/:id/reviews — public, approved reviews + summary. Also
+// tells a logged-in user whether they're eligible to review / already have.
+router.get('/:id/reviews', optionalAuth, async (req, res) => {
+  try {
+    const reviews = await db.query(`
+      SELECT id, reviewer_display, rating, body, created_at
+        FROM therapist_reviews
+       WHERE therapist_id = $1 AND status = 'approved'
+       ORDER BY created_at DESC
+    `, [req.params.id]);
+
+    const summary = await db.query(`
+      SELECT COUNT(*)::int AS count,
+             ROUND(AVG(rating)::numeric, 1) AS avg_rating
+        FROM therapist_reviews
+       WHERE therapist_id = $1 AND status = 'approved' AND rating IS NOT NULL
+    `, [req.params.id]);
+
+    // Eligibility: a logged-in user who has booked this therapist (themselves or
+    // via their couple) and hasn't already reviewed may leave one.
+    let canReview = false;
+    let alreadyReviewed = false;
+    if (req.user) {
+      const booked = await db.query(`
+        SELECT 1 FROM therapist_consultations tc
+        LEFT JOIN couples c ON c.id = tc.couple_id
+        WHERE tc.therapist_id = $1
+          AND (tc.requester_id = $2 OR c.user1_id = $2 OR c.user2_id = $2)
+        LIMIT 1
+      `, [req.params.id, req.user.id]);
+      const mine = await db.query(
+        `SELECT status FROM therapist_reviews WHERE therapist_id = $1 AND author_id = $2`,
+        [req.params.id, req.user.id]
+      );
+      alreadyReviewed = mine.rows.length > 0;
+      canReview = booked.rows.length > 0 && !alreadyReviewed;
+    }
+
+    res.json({
+      success: true,
+      summary: {
+        count: summary.rows[0].count || 0,
+        avgRating: summary.rows[0].avg_rating !== null ? Number(summary.rows[0].avg_rating) : null,
+      },
+      canReview,
+      alreadyReviewed,
+      reviews: reviews.rows.map((r) => ({
+        id: r.id,
+        reviewerDisplay: r.reviewer_display,
+        rating: r.rating,
+        body: r.body,
+        createdAt: r.created_at,
+      })),
+    });
+  } catch (error) {
+    logError('Failed to load therapist reviews', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '無法取得評價' });
+  }
+});
+
+// POST /api/therapists/:id/reviews — leave a review. Must have booked this
+// therapist; one review per author. Lands as 'pending' for admin moderation.
+router.post('/:id/reviews', authenticateToken, [
+  body('body').isString().trim().isLength({ min: 1, max: 4000 }).withMessage('評價內容需為 1-4000 字'),
+  body('rating').optional({ nullable: true }).isInt({ min: 1, max: 5 }).withMessage('評分需為 1-5'),
+  body('displayName').optional({ nullable: true }).isString().isLength({ max: 80 }),
+], async (req, res) => {
+  if (!handleValidation(req, res)) return;
+  try {
+    const therapistId = req.params.id;
+    const therapist = await db.query(`SELECT id, user_id FROM therapists WHERE id = $1`, [therapistId]);
+    if (therapist.rows.length === 0) {
+      return res.status(404).json({ success: false, message: '找不到這位諮商師' });
+    }
+    if (therapist.rows[0].user_id === req.user.id) {
+      return res.status(400).json({ success: false, error_code: 'SELF_REVIEW', message: '不能評價自己的檔案' });
+    }
+
+    const booked = await db.query(`
+      SELECT 1 FROM therapist_consultations tc
+      LEFT JOIN couples c ON c.id = tc.couple_id
+      WHERE tc.therapist_id = $1
+        AND (tc.requester_id = $2 OR c.user1_id = $2 OR c.user2_id = $2)
+      LIMIT 1
+    `, [therapistId, req.user.id]);
+    if (booked.rows.length === 0) {
+      return res.status(403).json({
+        success: false,
+        error_code: 'REVIEW_REQUIRES_CONSULTATION',
+        message: '與這位諮商師預約過後，才能留下評價',
+      });
+    }
+
+    const dup = await db.query(
+      `SELECT 1 FROM therapist_reviews WHERE therapist_id = $1 AND author_id = $2`,
+      [therapistId, req.user.id]
+    );
+    if (dup.rows.length > 0) {
+      return res.status(409).json({ success: false, error_code: 'ALREADY_REVIEWED', message: '你已經評價過這位諮商師了' });
+    }
+
+    // Use a provided display name, else mask the user's nickname.
+    let display = (req.body.displayName || '').trim();
+    if (!display) {
+      const u = await db.query(`SELECT nickname FROM users WHERE id = $1`, [req.user.id]);
+      display = maskName(u.rows[0] && u.rows[0].nickname);
+    }
+
+    await db.query(`
+      INSERT INTO therapist_reviews (therapist_id, author_id, reviewer_display, rating, body, status)
+      VALUES ($1, $2, $3, $4, $5, 'pending')
+    `, [therapistId, req.user.id, display.slice(0, 80), req.body.rating || null, req.body.body.trim()]);
+
+    logInfo('Therapist review submitted', { therapistId, userId: req.user.id });
+    res.status(201).json({ success: true, message: '感謝你的評價！我們會在審核後公開顯示。' });
+  } catch (error) {
+    logError('Failed to submit therapist review', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '送出評價失敗，請稍後再試' });
+  }
+});
+
 // --- Admin moderation (Basic-Auth gated in server.js) -------------------
 
 // GET /api/admin/therapists?status=pending — review queue. 'suspended' is a
@@ -952,6 +1785,233 @@ adminRouter.delete('/:id', async (req, res) => {
   } catch (error) {
     logError('Admin: failed to delete therapist', { id: req.params.id, err: error.message });
     res.status(500).json({ success: false, message: 'Failed to delete therapist' });
+  }
+});
+
+// GET /api/admin/therapists/reviews?status=pending — review moderation queue.
+adminRouter.get('/reviews', async (req, res) => {
+  try {
+    const status = ['pending', 'approved', 'hidden'].includes(req.query.status) ? req.query.status : 'pending';
+    const result = await db.query(`
+      SELECT r.id, r.therapist_id, r.reviewer_display, r.rating, r.body, r.status, r.created_at,
+             t.display_name AS therapist_name
+        FROM therapist_reviews r
+        JOIN therapists t ON t.id = r.therapist_id
+       WHERE r.status = $1
+       ORDER BY r.created_at DESC
+    `, [status]);
+    res.json({ success: true, reviews: result.rows });
+  } catch (error) {
+    logError('Admin: failed to list reviews', { err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to list reviews' });
+  }
+});
+
+// POST /api/admin/therapists/reviews/:id/moderate { action: 'approve'|'hide' }
+adminRouter.post('/reviews/:id/moderate', express.json(), async (req, res) => {
+  try {
+    const action = req.body && req.body.action;
+    const status = { approve: 'approved', hide: 'hidden' }[action];
+    if (!status) {
+      return res.status(400).json({ success: false, message: "action must be 'approve' or 'hide'" });
+    }
+    const result = await db.query(
+      `UPDATE therapist_reviews SET status = $1 WHERE id = $2 RETURNING id, status`,
+      [status, req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ success: false, message: 'Review not found' });
+    }
+    logInfo('Admin moderated review', { id: req.params.id, status });
+    res.json({ success: true, review: result.rows[0] });
+  } catch (error) {
+    logError('Admin: failed to moderate review', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to moderate review' });
+  }
+});
+
+// --- Admin: monthly Q&A revenue pool ------------------------------------
+//
+// The pool is paid out MANUALLY (ECPay only collects). These endpoints let an
+// admin set a month's pool, compute each active therapist's share from that
+// month's engagement, freeze it, and record manual payouts.
+
+// Aggregate a month's engagement per therapist: free-chat messages they sent,
+// threads they published, and helpful votes their published threads received.
+// The [monthStart, monthStart + 1 month) window is computed in SQL from a
+// 'YYYY-MM-01' string so server-timezone Date math can't shift the month.
+const aggregateMonthlyEngagement = async (periodMonth) => {
+  const result = await db.query(`
+    WITH win AS (SELECT $1::date AS s, ($1::date + interval '1 month') AS e)
+    SELECT t.id AS therapist_id,
+      (SELECT COUNT(*) FROM consultation_messages cm
+         JOIN therapist_consultations tc ON tc.id = cm.consultation_id, win
+        WHERE tc.therapist_id = t.id AND cm.sender_id = t.user_id
+          AND cm.created_at >= win.s AND cm.created_at < win.e) AS message_count,
+      (SELECT COUNT(*) FROM therapist_consultations tc, win
+        WHERE tc.therapist_id = t.id AND tc.public_status = 'published'
+          AND tc.published_at >= win.s AND tc.published_at < win.e) AS published_count,
+      (SELECT COUNT(*) FROM consultation_public_votes v
+         JOIN therapist_consultations tc ON tc.id = v.consultation_id, win
+        WHERE tc.therapist_id = t.id AND v.created_at >= win.s AND v.created_at < win.e) AS vote_count
+    FROM therapists t
+    WHERE t.status = 'approved' AND t.user_id IS NOT NULL
+  `, [periodMonth]);
+  return result.rows.map((r) => ({
+    therapist_id: r.therapist_id,
+    message_count: Number(r.message_count) || 0,
+    published_count: Number(r.published_count) || 0,
+    vote_count: Number(r.vote_count) || 0,
+  }));
+};
+
+// POST /api/admin/therapists/qa/pools { periodMonth: 'YYYY-MM-01', poolTwd, splitStrategy }
+adminRouter.post('/qa/pools', express.json(), async (req, res) => {
+  try {
+    const { periodMonth, poolTwd, splitStrategy } = req.body || {};
+    if (!/^\d{4}-\d{2}-01$/.test(String(periodMonth || ''))) {
+      return res.status(400).json({ success: false, message: "periodMonth must be 'YYYY-MM-01'" });
+    }
+    if (!Number.isInteger(poolTwd) || poolTwd < 0) {
+      return res.status(400).json({ success: false, message: 'poolTwd must be a non-negative integer' });
+    }
+    const strategy = ['even', 'volume', 'engagement'].includes(splitStrategy) ? splitStrategy : 'even';
+    const result = await db.query(`
+      INSERT INTO qa_revenue_pools (period_month, pool_twd, split_strategy, status)
+      VALUES ($1, $2, $3, 'draft')
+      ON CONFLICT (period_month) DO UPDATE
+        SET pool_twd = EXCLUDED.pool_twd, split_strategy = EXCLUDED.split_strategy
+        WHERE qa_revenue_pools.status IN ('draft', 'computed')
+      RETURNING *
+    `, [periodMonth, poolTwd, strategy]);
+    if (result.rows.length === 0) {
+      return res.status(409).json({ success: false, message: 'Pool already finalized for this month' });
+    }
+    logInfo('Admin created/updated QA pool', { periodMonth, poolTwd, strategy });
+    res.json({ success: true, pool: result.rows[0] });
+  } catch (error) {
+    logError('Admin: failed to create QA pool', { err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to create pool' });
+  }
+});
+
+// POST /api/admin/therapists/qa/pools/:id/compute — aggregate the month and
+// (re)compute each therapist's share. Allowed while draft/computed.
+adminRouter.post('/qa/pools/:id/compute', async (req, res) => {
+  try {
+    const poolRes = await db.query(`SELECT * FROM qa_revenue_pools WHERE id = $1`, [req.params.id]);
+    const pool = poolRes.rows[0];
+    if (!pool) return res.status(404).json({ success: false, message: 'Pool not found' });
+    if (!['draft', 'computed'].includes(pool.status)) {
+      return res.status(409).json({ success: false, message: 'Pool is finalized; cannot recompute' });
+    }
+
+    // Format the DATE back to 'YYYY-MM-01' from its own components (node-pg
+    // parses DATE to a local-midnight Date; local components match what's stored).
+    const pm = pool.period_month instanceof Date
+      ? `${pool.period_month.getFullYear()}-${String(pool.period_month.getMonth() + 1).padStart(2, '0')}-01`
+      : String(pool.period_month).slice(0, 10);
+
+    const stats = await aggregateMonthlyEngagement(pm);
+    const shares = qaPool.computeShares(pool.split_strategy, stats, pool.pool_twd);
+
+    await db.transaction(async (client) => {
+      // Recompute is idempotent: clear prior shares for this pool, reinsert.
+      await client.query(`DELETE FROM qa_revenue_shares WHERE pool_id = $1`, [req.params.id]);
+      for (const s of shares) {
+        await client.query(`
+          INSERT INTO qa_revenue_shares
+            (pool_id, therapist_id, message_count, published_count, vote_count, weight, share_twd)
+          VALUES ($1,$2,$3,$4,$5,$6,$7)
+        `, [req.params.id, s.therapist_id, s.message_count, s.published_count, s.vote_count, s.weight, s.share_twd]);
+      }
+      await client.query(`UPDATE qa_revenue_pools SET status = 'computed', computed_at = NOW() WHERE id = $1`, [req.params.id]);
+    });
+
+    logInfo('Admin computed QA pool shares', { poolId: req.params.id, recipients: shares.length });
+    res.json({ success: true, recipients: shares.length, totalAllocated: shares.reduce((a, s) => a + s.share_twd, 0) });
+  } catch (error) {
+    logError('Admin: failed to compute QA pool', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to compute pool' });
+  }
+});
+
+// POST /api/admin/therapists/qa/pools/:id/finalize — freeze the computed shares.
+adminRouter.post('/qa/pools/:id/finalize', async (req, res) => {
+  try {
+    const result = await db.query(
+      `UPDATE qa_revenue_pools SET status = 'finalized', finalized_at = NOW()
+        WHERE id = $1 AND status = 'computed' RETURNING id, status`,
+      [req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(409).json({ success: false, message: 'Pool must be computed before finalizing' });
+    }
+    logInfo('Admin finalized QA pool', { poolId: req.params.id });
+    res.json({ success: true, pool: result.rows[0] });
+  } catch (error) {
+    logError('Admin: failed to finalize QA pool', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to finalize pool' });
+  }
+});
+
+// POST /api/admin/therapists/qa/shares/:id/mark-paid { note } — record a manual
+// payout to a therapist (no automated transfer; ECPay only collects).
+adminRouter.post('/qa/shares/:id/mark-paid', express.json(), async (req, res) => {
+  try {
+    const result = await db.query(
+      `UPDATE qa_revenue_shares SET payout_status = 'paid', paid_at = NOW(), payout_note = $2
+        WHERE id = $1 RETURNING id, payout_status`,
+      [req.params.id, (req.body && req.body.note) || null]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ success: false, message: 'Share not found' });
+    }
+    // If all shares for the pool are paid, mark the pool paid_out.
+    await db.query(`
+      UPDATE qa_revenue_pools p SET status = 'paid_out'
+       WHERE p.id = (SELECT pool_id FROM qa_revenue_shares WHERE id = $1)
+         AND p.status = 'finalized'
+         AND NOT EXISTS (SELECT 1 FROM qa_revenue_shares s WHERE s.pool_id = p.id AND s.payout_status <> 'paid')
+    `, [req.params.id]);
+    logInfo('Admin marked QA share paid', { shareId: req.params.id });
+    res.json({ success: true, share: result.rows[0] });
+  } catch (error) {
+    logError('Admin: failed to mark share paid', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to mark paid' });
+  }
+});
+
+// GET /api/admin/therapists/qa/pools — list pools (newest first).
+adminRouter.get('/qa/pools', async (req, res) => {
+  try {
+    const result = await db.query(`
+      SELECT p.*,
+        (SELECT COUNT(*) FROM qa_revenue_shares s WHERE s.pool_id = p.id) AS recipient_count,
+        (SELECT COALESCE(SUM(share_twd),0) FROM qa_revenue_shares s WHERE s.pool_id = p.id) AS allocated_twd
+      FROM qa_revenue_pools p ORDER BY p.period_month DESC
+    `);
+    res.json({ success: true, pools: result.rows });
+  } catch (error) {
+    logError('Admin: failed to list QA pools', { err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to list pools' });
+  }
+});
+
+// GET /api/admin/therapists/qa/pools/:id — pool + per-therapist shares.
+adminRouter.get('/qa/pools/:id', async (req, res) => {
+  try {
+    const pool = await db.query(`SELECT * FROM qa_revenue_pools WHERE id = $1`, [req.params.id]);
+    if (pool.rows.length === 0) return res.status(404).json({ success: false, message: 'Pool not found' });
+    const shares = await db.query(`
+      SELECT s.*, t.display_name AS therapist_name
+        FROM qa_revenue_shares s JOIN therapists t ON t.id = s.therapist_id
+       WHERE s.pool_id = $1 ORDER BY s.share_twd DESC
+    `, [req.params.id]);
+    res.json({ success: true, pool: pool.rows[0], shares: shares.rows });
+  } catch (error) {
+    logError('Admin: failed to get QA pool', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: 'Failed to get pool' });
   }
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Calendar, MessageCircle, Clock, MapPin, Play, Coins, User, StickyNote, MessageSquareHeart, Trash2, Pencil } from 'lucide-react';
 import SettingsView from './components/SettingsView';
 import UpgradeView, { BillingResultView } from './components/UpgradeView';
+import { BookingResultView } from './components/BookingResultView';
 import RoleplayView from './components/RoleplayView';
 import ScriptUploadModal from './components/ScriptUploadModal';
 import GamesView from './components/GamesView';
@@ -413,6 +414,10 @@ const LoveTimeApp = () => {
   // True when ECPay redirected the browser back to /billing/result.
   const [isBillingResult, setIsBillingResult] = useState(() =>
     typeof window !== 'undefined' && window.location.pathname.startsWith('/billing/result')
+  );
+  // True when ECPay redirected the browser back to /booking/result (video session).
+  const [isBookingResult, setIsBookingResult] = useState(() =>
+    typeof window !== 'undefined' && window.location.pathname.startsWith('/booking/result')
   );
   const [pendingEventId, setPendingEventId] = useState<string | null>(null);
   const [pendingScriptTitle, setPendingScriptTitle] = useState<string | null>(null);
@@ -2032,6 +2037,20 @@ const LoveTimeApp = () => {
           window.history.replaceState(null, '', '/');
           setIsBillingResult(false);
           setCurrentView('record');
+        }}
+      />
+    );
+  }
+
+  // ECPay redirected back after a video-session payment. The session was marked
+  // paid server-to-server; this screen just confirms and returns to the app.
+  if (isBookingResult) {
+    return (
+      <BookingResultView
+        onDone={() => {
+          window.history.replaceState(null, '', '/');
+          setIsBookingResult(false);
+          setCurrentView('therapists');
         }}
       />
     );

--- a/src/components/BookingResultView.tsx
+++ b/src/components/BookingResultView.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Video } from 'lucide-react';
+
+// Landing screen ECPay returns the browser to after a video-session payment
+// (path /booking/result). The session was already marked paid server-to-server;
+// this screen just reports the outcome and returns to the app.
+export const BookingResultView: React.FC<{ onDone: () => void }> = ({ onDone }) => {
+  const params = new URLSearchParams(window.location.search);
+  const success = params.get('status') !== 'failed';
+
+  return (
+    <div className="min-h-screen bg-petal-cream flex items-center justify-center p-4">
+      <div className="max-w-md w-full text-center bg-petal-cream rounded-md border border-petal-rule shadow-petal p-8">
+        {success ? (
+          <>
+            <Video className="w-8 h-8 text-pink-600 mx-auto mb-3" strokeWidth={1.5} />
+            <h2 className="font-display text-2xl font-light text-petal-ink mb-2">付款成功</h2>
+            <p className="font-body text-sm text-petal-ink-soft mb-6">
+              預約已確認。諮商師接受後會提供視訊會議連結，你可以在「我的預約」中查看。
+            </p>
+          </>
+        ) : (
+          <>
+            <h2 className="font-display text-2xl font-light text-petal-ink mb-2">付款未完成</h2>
+            <p className="font-body text-sm text-petal-ink-soft mb-6">
+              這次沒有完成付款。你可以回到「我的預約」再試一次。
+            </p>
+          </>
+        )}
+        <button
+          onClick={onDone}
+          data-testid="booking-result-done"
+          className="w-full py-3 rounded-md bg-petal-ink text-petal-cream hover:bg-pink-700 transition-colors font-display italic text-base"
+        >
+          回到 Twogether
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BookingResultView;

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+// A pill toggle used by the therapist focus-area filters (directory + 公開問答).
+export const FilterChip: React.FC<{ active: boolean; onClick: () => void; label: string; emoji: string }> = ({
+  active, onClick, label, emoji,
+}) => (
+  <button
+    onClick={onClick}
+    className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-full transition-colors border font-body text-[13px] font-medium tracking-tight ${
+      active
+        ? 'bg-petal-ink text-petal-cream border-petal-ink'
+        : 'bg-transparent text-petal-ink-soft border-petal-rule hover:border-petal-ink hover:text-petal-ink'
+    }`}
+  >
+    <span>{emoji}</span>
+    <span>{label}</span>
+  </button>
+);
+
+export default FilterChip;

--- a/src/components/PublicQaView.tsx
+++ b/src/components/PublicQaView.tsx
@@ -1,0 +1,276 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Heart, MessageCircle, ThumbsUp, ChevronLeft, Sparkles } from 'lucide-react';
+import {
+  apiService,
+  type TherapistFocusArea,
+  type PublicQaThreadSummary,
+  type PublicQaThread,
+} from '../services/api';
+import type { Notification } from './ErrorNotification';
+import { FOCUS_AREAS, focusLabel } from './therapistShared';
+import { FilterChip } from './FilterChip';
+
+// 公開問答 (Public Q&A): a read-only, anonymised browse of consultation chats
+// that both the client and therapist agreed to publish. Helps people with
+// similar problems learn from how a therapist handled it. The asker is always
+// shown as "匿名個案"; only the therapist is identified.
+
+interface PublicQaViewProps {
+  isAuthenticated: boolean;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+  // Opens the directory tab focused on a therapist (so a reader can go book one).
+  onFindTherapist?: () => void;
+}
+
+const TherapistMini: React.FC<{ therapist: PublicQaThreadSummary['therapist'] }> = ({ therapist }) => (
+  <div className="flex items-center gap-2 min-w-0">
+    <div className="w-7 h-7 shrink-0 rounded-full overflow-hidden bg-petal-cream-2 border border-petal-rule flex items-center justify-center">
+      {therapist.photoUrl ? (
+        <img src={therapist.photoUrl} alt={therapist.displayName} className="w-full h-full object-contain" />
+      ) : (
+        <Heart className="w-3.5 h-3.5 text-pink-300" strokeWidth={1.5} />
+      )}
+    </div>
+    <span className="font-body text-xs text-petal-ink-soft truncate">
+      {therapist.displayName}
+      {therapist.title ? <span className="text-petal-muted">・{therapist.title}</span> : null}
+    </span>
+  </div>
+);
+
+const PublicQaView: React.FC<PublicQaViewProps> = ({ isAuthenticated, showNotification, onFindTherapist }) => {
+  const [focus, setFocus] = useState<TherapistFocusArea | 'all'>('all');
+  const [threads, setThreads] = useState<PublicQaThreadSummary[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const load = useCallback(async (nextPage: number, replace: boolean) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await apiService.getPublicQa(focus === 'all' ? undefined : focus, nextPage);
+      setThreads((prev) => (replace ? res.threads : [...prev, ...res.threads]));
+      setHasMore(res.hasMore);
+      setPage(res.page);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '無法取得公開問答列表');
+    } finally {
+      setLoading(false);
+    }
+  }, [focus]);
+
+  useEffect(() => { load(1, true); }, [load]);
+
+  if (openId) {
+    return (
+      <PublicQaDetail
+        id={openId}
+        isAuthenticated={isAuthenticated}
+        showNotification={showNotification}
+        onBack={() => setOpenId(null)}
+        onFindTherapist={onFindTherapist}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6" data-testid="public-qa-view">
+      <div className="text-center max-w-2xl mx-auto">
+        <p className="font-body text-sm text-petal-ink-soft">
+          這些是經諮商師與個案雙方同意、<span className="text-petal-ink">匿名公開</span>的對話。
+          也許別人的經驗，正好能幫上你。
+        </p>
+      </div>
+
+      {/* Focus filter */}
+      <div className="flex flex-wrap justify-center gap-1.5">
+        <FilterChip active={focus === 'all'} onClick={() => setFocus('all')} label="全部" emoji="✨" />
+        {FOCUS_AREAS.map((f) => (
+          <FilterChip key={f.id} active={focus === f.id} onClick={() => setFocus(f.id)} label={f.label} emoji={f.emoji} />
+        ))}
+      </div>
+
+      {loading && threads.length === 0 ? (
+        <p className="text-center font-body text-sm text-petal-muted py-12">載入中…</p>
+      ) : error ? (
+        <div className="text-center py-12">
+          <p className="font-body text-sm text-petal-rose-deep mb-3">{error}</p>
+          <button onClick={() => load(1, true)} className="font-body text-sm text-petal-ink underline underline-offset-4">
+            重新載入
+          </button>
+        </div>
+      ) : threads.length === 0 ? (
+        <p className="text-center font-body text-sm text-petal-muted py-12">
+          這個領域還沒有公開問答。換個領域看看，或成為第一個分享對話的人。
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4" data-testid="public-qa-list">
+            {threads.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => setOpenId(t.id)}
+                data-testid="public-qa-card"
+                className="text-left flex flex-col bg-petal-cream rounded-lg border border-petal-rule shadow-petal p-5 hover:border-petal-ink transition-colors"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <h3 className="font-display text-lg font-medium text-petal-ink line-clamp-2">{t.title}</h3>
+                  {t.focusArea && (
+                    <span className="shrink-0 px-2 py-0.5 rounded-full bg-petal-cream-2 border border-petal-rule font-body text-[11px] text-petal-ink-soft">
+                      {focusLabel(t.focusArea)}
+                    </span>
+                  )}
+                </div>
+                {t.preview && (
+                  <p className="mt-2 font-body text-sm text-petal-ink-soft line-clamp-3">{t.preview}</p>
+                )}
+                <div className="mt-3 pt-3 border-t border-petal-rule flex items-center justify-between gap-3">
+                  <TherapistMini therapist={t.therapist} />
+                  <div className="flex items-center gap-3 font-body text-[11px] text-petal-muted shrink-0">
+                    <span className="inline-flex items-center gap-1"><ThumbsUp className="w-3 h-3" strokeWidth={1.5} /> {t.helpfulCount}</span>
+                    <span className="inline-flex items-center gap-1"><MessageCircle className="w-3 h-3" strokeWidth={1.5} /> {t.messageCount}</span>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+          {hasMore && (
+            <div className="text-center">
+              <button
+                onClick={() => load(page + 1, false)}
+                disabled={loading}
+                className="px-5 py-2 rounded-full border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors font-body text-[13px] font-medium disabled:opacity-50"
+              >
+                {loading ? '載入中…' : '載入更多'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+// --- Read-only thread detail ----------------------------------------------
+
+const PublicQaDetail: React.FC<{
+  id: string;
+  isAuthenticated: boolean;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+  onBack: () => void;
+  onFindTherapist?: () => void;
+}> = ({ id, isAuthenticated, showNotification, onBack, onFindTherapist }) => {
+  const [thread, setThread] = useState<PublicQaThread | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [voting, setVoting] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    apiService.getPublicQaThread(id)
+      .then((t) => { if (alive) setThread(t); })
+      .catch((err) => { if (alive) setError(err instanceof Error ? err.message : '無法載入公開問答'); });
+    return () => { alive = false; };
+  }, [id]);
+
+  const toggleVote = async () => {
+    if (!isAuthenticated) {
+      showNotification({ type: 'info', title: '請先登入', message: '登入後就能標記對你有幫助的公開問答', duration: 3500 });
+      return;
+    }
+    if (!thread) return;
+    try {
+      setVoting(true);
+      const res = await apiService.votePublicQa(thread.id);
+      setThread({ ...thread, hasVoted: res.voted, helpfulCount: res.helpfulCount });
+    } catch (err) {
+      showNotification({ type: 'error', title: '操作失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 3500 });
+    } finally {
+      setVoting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5 max-w-2xl mx-auto">
+      <button onClick={onBack} className="inline-flex items-center gap-1 font-body text-sm text-petal-muted hover:text-petal-ink">
+        <ChevronLeft className="w-4 h-4" strokeWidth={1.5} /> 回到公開問答
+      </button>
+
+      {error ? (
+        <p className="text-center font-body text-sm text-petal-rose-deep py-12">{error}</p>
+      ) : !thread ? (
+        <p className="text-center font-body text-sm text-petal-muted py-12">載入中…</p>
+      ) : (
+        <div className="bg-petal-cream rounded-lg border border-petal-rule shadow-petal" data-testid="public-qa-detail">
+          <div className="px-5 py-4 border-b border-petal-rule">
+            <div className="flex items-start justify-between gap-3">
+              <h2 className="font-display text-2xl font-light text-petal-ink">{thread.title}</h2>
+              {thread.focusArea && (
+                <span className="shrink-0 px-2 py-0.5 rounded-full bg-petal-cream-2 border border-petal-rule font-body text-[11px] text-petal-ink-soft mt-1">
+                  {focusLabel(thread.focusArea)}
+                </span>
+              )}
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <TherapistMini therapist={thread.therapist} />
+              <span className="font-body text-[11px] text-petal-muted">回答</span>
+            </div>
+          </div>
+
+          {/* Anonymised transcript */}
+          <div className="px-4 py-4 space-y-3">
+            {thread.messages.map((m) => (
+              <div key={m.id} className={`flex ${m.isTherapist ? 'justify-start' : 'justify-end'}`}>
+                <div className={`max-w-[82%] flex flex-col ${m.isTherapist ? 'items-start' : 'items-end'}`}>
+                  <div className="font-body text-[11px] text-petal-muted mb-0.5 px-1">
+                    {m.isTherapist ? `🩺 ${m.senderName}（諮商師）` : m.senderName}
+                  </div>
+                  <div
+                    className={`px-3.5 py-2 rounded-2xl font-body text-sm ${
+                      m.isTherapist
+                        ? 'bg-pink-100 text-petal-ink rounded-bl-sm'
+                        : 'bg-petal-cream-2 text-petal-ink rounded-br-sm'
+                    }`}
+                  >
+                    {m.body}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Footer: helpful vote + CTA to find a therapist */}
+          <div className="px-5 py-4 border-t border-petal-rule flex items-center justify-between gap-3">
+            <button
+              onClick={toggleVote}
+              disabled={voting}
+              data-testid="public-qa-vote"
+              className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full border font-body text-[13px] font-medium transition-colors disabled:opacity-50 ${
+                thread.hasVoted
+                  ? 'bg-pink-500 text-white border-pink-500'
+                  : 'border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink'
+              }`}
+            >
+              <ThumbsUp className="w-3.5 h-3.5" strokeWidth={1.5} />
+              有幫助 {thread.helpfulCount > 0 ? thread.helpfulCount : ''}
+            </button>
+            {onFindTherapist && (
+              <button
+                onClick={onFindTherapist}
+                className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-petal-ink text-petal-cream hover:bg-pink-700 transition-colors font-body text-[13px] font-medium"
+              >
+                <Sparkles className="w-3.5 h-3.5" strokeWidth={1.5} />
+                找諮商師聊聊
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PublicQaView;

--- a/src/components/TherapistProfileModal.tsx
+++ b/src/components/TherapistProfileModal.tsx
@@ -1,0 +1,305 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { X, Heart, Award, Languages, Star, ExternalLink, CalendarCheck } from 'lucide-react';
+import {
+  apiService,
+  type Therapist,
+  type TherapistReview,
+  type TherapistReviewsResult,
+  type TherapistLinkItem,
+} from '../services/api';
+import type { Notification } from './ErrorNotification';
+import { useScrollLock } from '../hooks/useScrollLock';
+import { focusLabel, formatNtd } from './therapistShared';
+
+const LANGUAGE_LABEL: Record<string, string> = { zh: '中文', en: 'English', ja: '日本語', ko: '한국어' };
+const languageLabel = (c: string) => LANGUAGE_LABEL[c] || c;
+
+// A titled section that renders nothing when empty, so a sparse profile stays clean.
+const Section: React.FC<{ title: string; children: React.ReactNode; show?: boolean }> = ({ title, children, show = true }) =>
+  show ? (
+    <section className="px-5 sm:px-6 py-4 border-t border-petal-rule">
+      <h4 className="font-display text-base text-pink-700 mb-2">【{title}】</h4>
+      {children}
+    </section>
+  ) : null;
+
+const TextBlock: React.FC<{ text?: string | null }> = ({ text }) =>
+  text ? <p className="font-body text-sm text-petal-ink-soft leading-relaxed whitespace-pre-wrap">{text}</p> : null;
+
+const BulletList: React.FC<{ items?: string[] }> = ({ items }) =>
+  items && items.length > 0 ? (
+    <ul className="space-y-1">
+      {items.map((it, i) => (
+        <li key={i} className="font-body text-sm text-petal-ink-soft leading-relaxed pl-3 relative">
+          <span className="absolute left-0 text-petal-rose">·</span>{it}
+        </li>
+      ))}
+    </ul>
+  ) : null;
+
+const LinkList: React.FC<{ items?: TherapistLinkItem[] }> = ({ items }) =>
+  items && items.length > 0 ? (
+    <ul className="space-y-1.5">
+      {items.map((it, i) => {
+        const href = it.url || it.source || '';
+        return (
+          <li key={i} className="font-body text-sm text-petal-ink-soft leading-relaxed pl-3 relative">
+            <span className="absolute left-0 text-petal-rose">·</span>
+            {href ? (
+              <a href={href} target="_blank" rel="noopener noreferrer" className="text-petal-ink underline underline-offset-2 hover:text-pink-700 inline-flex items-center gap-1">
+                {it.title}<ExternalLink className="w-3 h-3 shrink-0" strokeWidth={1.5} />
+              </a>
+            ) : (
+              it.title
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  ) : null;
+
+const Stars: React.FC<{ value: number; onChange?: (v: number) => void }> = ({ value, onChange }) => (
+  <div className="inline-flex items-center gap-0.5">
+    {[1, 2, 3, 4, 5].map((n) => (
+      <button
+        key={n}
+        type="button"
+        disabled={!onChange}
+        onClick={() => onChange?.(n)}
+        className={onChange ? 'cursor-pointer' : 'cursor-default'}
+        aria-label={`${n} 星`}
+      >
+        <Star className={`w-4 h-4 ${n <= value ? 'text-pink-500 fill-pink-500' : 'text-petal-rule'}`} strokeWidth={1.5} />
+      </button>
+    ))}
+  </div>
+);
+
+interface TherapistProfileModalProps {
+  therapist: Therapist;
+  isAuthenticated: boolean;
+  onClose: () => void;
+  onBook: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}
+
+const TherapistProfileModal: React.FC<TherapistProfileModalProps> = ({ therapist: t, isAuthenticated, onClose, onBook, showNotification }) => {
+  useScrollLock(true);
+  const [reviews, setReviews] = useState<TherapistReviewsResult | null>(null);
+
+  const loadReviews = useCallback(async () => {
+    try {
+      setReviews(await apiService.getTherapistReviews(t.id));
+    } catch {
+      /* non-fatal: profile still shows without reviews */
+    }
+  }, [t.id]);
+
+  useEffect(() => { loadReviews(); }, [loadReviews]);
+
+  const hasAnyRichSection = Boolean(
+    t.introMessage || t.approach || t.about ||
+    (t.certifications && t.certifications.length) ||
+    (t.currentPositions && t.currentPositions.length) ||
+    (t.qualifications && t.qualifications.length) ||
+    (t.training && t.training.length) ||
+    (t.publications && t.publications.length) ||
+    (t.articles && t.articles.length)
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-0 sm:p-4">
+      <div className="bg-petal-cream w-full sm:max-w-2xl max-h-[94vh] overflow-y-auto rounded-t-2xl sm:rounded-lg border border-petal-rule shadow-petal" data-testid="therapist-profile-modal">
+        {/* Header */}
+        <div className="sticky top-0 z-10 bg-petal-cream flex items-center justify-between px-5 sm:px-6 py-4 border-b border-petal-rule">
+          <h3 className="font-display text-xl font-medium text-petal-ink">諮商師檔案</h3>
+          <button onClick={onClose} className="p-1 text-petal-muted hover:text-petal-ink" aria-label="關閉">
+            <X className="w-5 h-5" strokeWidth={1.5} />
+          </button>
+        </div>
+
+        {/* Top card */}
+        <div className="px-5 sm:px-6 py-5 flex gap-4">
+          <div className="w-24 h-24 shrink-0 rounded-full overflow-hidden bg-petal-cream-2 border border-petal-rule flex items-center justify-center">
+            {t.photoUrl ? (
+              <img src={t.photoUrl} alt={t.displayName} className="w-full h-full object-contain" />
+            ) : (
+              <Heart className="w-10 h-10 text-pink-300" strokeWidth={1.5} />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <h2 className="font-display text-2xl font-light text-petal-ink">{t.displayName}</h2>
+              {t.title && <span className="font-body text-sm text-petal-muted">{t.title}</span>}
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 font-body text-xs text-petal-ink-soft">
+              {typeof t.yearsExperience === 'number' && (
+                <span className="inline-flex items-center gap-1"><Award className="w-3 h-3" strokeWidth={1.5} /> {t.yearsExperience} 年資歷</span>
+              )}
+              {t.languages.length > 0 && (
+                <span className="inline-flex items-center gap-1"><Languages className="w-3 h-3" strokeWidth={1.5} /> {t.languages.map(languageLabel).join('・')}</span>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-1.5 mt-2.5">
+              {t.focusAreas.map((a) => (
+                <span key={a} className="px-2 py-0.5 rounded-full bg-petal-cream-2 border border-petal-rule font-body text-[11px] text-petal-ink-soft">#{focusLabel(a)}</span>
+              ))}
+              {(t.customSpecialties || []).map((s) => (
+                <span key={s} className="px-2 py-0.5 rounded-full bg-pink-50 border border-pink-200 font-body text-[11px] text-pink-700">#{s}</span>
+              ))}
+            </div>
+            {reviews && reviews.summary.count > 0 && reviews.summary.avgRating !== null && (
+              <div className="mt-2.5 inline-flex items-center gap-1.5">
+                <Stars value={Math.round(reviews.summary.avgRating)} />
+                <span className="font-body text-xs text-petal-ink-soft">{reviews.summary.avgRating} · {reviews.summary.count} 則評價</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Booking bar */}
+        <div className="px-5 sm:px-6 pb-4 flex items-center justify-between gap-3">
+          <div className="font-body text-sm text-petal-ink">
+            <span className="font-display text-lg text-pink-600">{formatNtd(t.rateTwd)}</span>
+            <span className="text-petal-muted text-xs"> / {t.sessionMinutes} 分鐘</span>
+          </div>
+          {t.acceptingNewClients === false ? (
+            <span className="font-body text-xs text-petal-muted px-3 py-2 rounded-full border border-petal-rule">暫不開放新案預約</span>
+          ) : (
+            <button
+              onClick={onBook}
+              data-testid="profile-book-button"
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-pink-500 text-white hover:bg-pink-600 transition-colors font-body text-[13px] font-medium"
+            >
+              <CalendarCheck className="w-3.5 h-3.5" strokeWidth={1.5} /> 預約諮詢
+            </button>
+          )}
+        </div>
+
+        {/* Rich sections */}
+        <Section title="給來談者的一段話" show={!!t.introMessage}><TextBlock text={t.introMessage} /></Section>
+        <Section title="自我介紹" show={!!t.bio}><TextBlock text={t.bio} /></Section>
+        <Section title="心理師證照" show={!!(t.certifications && t.certifications.length)}><BulletList items={t.certifications} /></Section>
+        <Section title="治療取向／治療理念" show={!!t.approach}><TextBlock text={t.approach} /></Section>
+        <Section title="認識治療師" show={!!t.about}><TextBlock text={t.about} /></Section>
+        <Section title="現任" show={!!(t.currentPositions && t.currentPositions.length)}><BulletList items={t.currentPositions} /></Section>
+        <Section title="專業資格" show={!!(t.qualifications && t.qualifications.length)}><BulletList items={t.qualifications} /></Section>
+        <Section title="專業訓練" show={!!(t.training && t.training.length)}><BulletList items={t.training} /></Section>
+        <Section title="心理專業著作" show={!!(t.publications && t.publications.length)}><LinkList items={t.publications} /></Section>
+        <Section title="心理專業文章" show={!!(t.articles && t.articles.length)}><LinkList items={t.articles} /></Section>
+
+        {!hasAnyRichSection && !t.bio && (
+          <div className="px-5 sm:px-6 py-4 border-t border-petal-rule">
+            <p className="font-body text-sm text-petal-muted">這位諮商師尚未填寫詳細介紹。</p>
+          </div>
+        )}
+
+        {/* Reviews */}
+        <ReviewsSection
+          therapistId={t.id}
+          isAuthenticated={isAuthenticated}
+          reviews={reviews}
+          onSubmitted={loadReviews}
+          showNotification={showNotification}
+        />
+      </div>
+    </div>
+  );
+};
+
+// --- Reviews section ------------------------------------------------------
+
+const ReviewCard: React.FC<{ review: TherapistReview }> = ({ review }) => (
+  <div className="rounded-md border border-petal-rule p-4" data-testid="review-card">
+    <div className="flex items-center justify-between gap-2">
+      <span className="font-display text-base text-petal-ink">{review.reviewerDisplay}</span>
+      {typeof review.rating === 'number' && <Stars value={review.rating} />}
+    </div>
+    <p className="mt-1.5 font-body text-sm text-petal-ink-soft leading-relaxed whitespace-pre-wrap">{review.body}</p>
+  </div>
+);
+
+const ReviewsSection: React.FC<{
+  therapistId: string;
+  isAuthenticated: boolean;
+  reviews: TherapistReviewsResult | null;
+  onSubmitted: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ therapistId, isAuthenticated, reviews, onSubmitted, showNotification }) => {
+  const [body, setBody] = useState('');
+  const [rating, setRating] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const submit = async () => {
+    if (!body.trim()) return;
+    try {
+      setSubmitting(true);
+      const res = await apiService.submitTherapistReview(therapistId, {
+        body: body.trim(),
+        rating: rating || undefined,
+      });
+      setDone(true);
+      setBody('');
+      setRating(0);
+      showNotification({ type: 'success', title: '已送出評價', message: res.message, duration: 4000 });
+      onSubmitted();
+    } catch (err) {
+      showNotification({ type: 'error', title: '送出失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 4000 });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="px-5 sm:px-6 py-5 border-t border-petal-rule bg-petal-cream-2/40" data-testid="reviews-section">
+      <h4 className="font-display text-base text-pink-700 mb-3">客戶評價</h4>
+
+      {reviews && reviews.reviews.length > 0 ? (
+        <div className="space-y-3">{reviews.reviews.map((r) => <ReviewCard key={r.id} review={r} />)}</div>
+      ) : (
+        <p className="font-body text-sm text-petal-muted">還沒有評價。</p>
+      )}
+
+      {/* Submission */}
+      <div className="mt-4">
+        {!isAuthenticated ? (
+          <p className="font-body text-xs text-petal-muted">登入並與這位諮商師預約過後，就能留下評價。</p>
+        ) : done || (reviews && reviews.alreadyReviewed) ? (
+          <p className="font-body text-xs text-petal-sage-deep">你已留下評價，審核通過後會公開顯示。謝謝你！</p>
+        ) : reviews && reviews.canReview ? (
+          <div className="rounded-md border border-petal-rule bg-petal-cream p-4 space-y-2.5">
+            <div className="flex items-center gap-2">
+              <span className="font-body text-xs text-petal-ink-soft">給個評分（選填）</span>
+              <Stars value={rating} onChange={setRating} />
+            </div>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              maxLength={4000}
+              rows={3}
+              placeholder="分享你的諮商經驗，幫助其他人選擇…"
+              data-testid="review-input"
+              className="w-full px-3 py-2 rounded-md border border-petal-rule bg-petal-cream focus:border-petal-ink focus:outline-none font-body text-sm text-petal-ink resize-y"
+            />
+            <div className="flex items-center justify-between">
+              <span className="font-body text-[11px] text-petal-muted">送出後會匿名顯示（例如「林O儀」），並經審核後公開。</span>
+              <button
+                onClick={submit}
+                disabled={submitting || !body.trim()}
+                data-testid="review-submit"
+                className="px-4 py-1.5 rounded-full bg-petal-ink text-petal-cream hover:bg-pink-700 disabled:opacity-40 font-body text-xs font-medium"
+              >
+                送出評價
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="font-body text-xs text-petal-muted">與這位諮商師預約過後，就能留下評價。</p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default TherapistProfileModal;

--- a/src/components/TherapistsView.tsx
+++ b/src/components/TherapistsView.tsx
@@ -1,17 +1,24 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Heart, Sparkles, X, UserPlus, Clock, Languages, Award, CalendarCheck, MessageCircle, Send, StickyNote, UserCog, Upload, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Heart, Sparkles, X, UserPlus, Clock, Languages, Award, CalendarCheck, MessageCircle, Send, StickyNote, UserCog, Upload, CheckCircle2, AlertCircle, Globe, Users, Video, Wallet } from 'lucide-react';
 import {
   apiService,
   type Therapist,
   type TherapistFocusArea,
   type TherapistConsultation,
   type ConsultationThread,
+  type ConsultationPublicStatus,
+  type MeetingProvider,
+  type TherapistEarnings,
   type EventRecord,
   type OwnTherapistProfile,
   type TherapistProfileUpdate,
 } from '../services/api';
 import type { Notification } from './ErrorNotification';
 import { useScrollLock } from '../hooks/useScrollLock';
+import { FOCUS_AREAS, focusLabel, formatNtd } from './therapistShared';
+import { FilterChip } from './FilterChip';
+import PublicQaView from './PublicQaView';
+import TherapistProfileModal from './TherapistProfileModal';
 
 interface TherapistsViewProps {
   authState: {
@@ -22,29 +29,6 @@ interface TherapistsViewProps {
   showNotification: (notification: Omit<Notification, 'id'>) => void;
 }
 
-// Focus areas — keep the value/label/emoji in one place so the filter chips,
-// cards, and forms all read from the same source of truth. Order matches the
-// backend FOCUS_AREAS list in routes/therapists.js.
-const FOCUS_AREAS: { id: TherapistFocusArea; label: string; emoji: string }[] = [
-  { id: 'couple', label: '伴侶關係', emoji: '💞' },
-  { id: 'family', label: '家庭', emoji: '🏡' },
-  { id: 'childhood', label: '童年/原生家庭', emoji: '🧸' },
-  { id: 'individual', label: '個人成長', emoji: '🌱' },
-  { id: 'sexuality', label: '性與親密', emoji: '🔥' },
-  { id: 'parenting', label: '親職教養', emoji: '👶' },
-  { id: 'grief', label: '悲傷失落', emoji: '🕊️' },
-  { id: 'anxiety', label: '焦慮憂鬱', emoji: '🌧️' },
-  { id: 'depression', label: '憂鬱情緒', emoji: '🌫️' },
-  { id: 'trauma', label: '創傷', emoji: '💔' },
-  { id: 'addiction', label: '成癮', emoji: '🎯' },
-  { id: 'lgbtq', label: '性別與多元認同', emoji: '🏳️‍🌈' },
-  { id: 'career', label: '職涯/工作壓力', emoji: '💼' },
-  { id: 'self_esteem', label: '自我價值', emoji: '✨' },
-];
-
-const focusLabel = (id: string): string =>
-  FOCUS_AREAS.find((f) => f.id === id)?.label || id;
-
 const LANGUAGE_LABEL: Record<string, string> = {
   zh: '中文',
   en: 'English',
@@ -53,14 +37,22 @@ const LANGUAGE_LABEL: Record<string, string> = {
 };
 const languageLabel = (code: string): string => LANGUAGE_LABEL[code] || code;
 
-const formatNtd = (n: number): string => `NT$${n.toLocaleString('en-US')}`;
-
 const CONSULTATION_STATUS: Record<TherapistConsultation['status'], { label: string; cls: string }> = {
   pending: { label: '等待回覆', cls: 'text-petal-rose-deep' },
   accepted: { label: '已接受', cls: 'text-petal-sage-deep' },
   declined: { label: '已婉拒', cls: 'text-petal-muted' },
   completed: { label: '已完成', cls: 'text-petal-sage-deep' },
   cancelled: { label: '已取消', cls: 'text-petal-muted' },
+  no_show: { label: '未出席', cls: 'text-petal-muted' },
+};
+
+// 公開問答 publish state → label shown in the chat room / consultation list.
+const PUBLIC_STATUS_LABEL: Record<ConsultationPublicStatus, string> = {
+  private: '私密',
+  client_requested: '等待對方同意公開',
+  therapist_requested: '等待對方同意公開',
+  published: '已公開為公開問答',
+  withdrawn: '已取消公開',
 };
 
 const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotification }) => {
@@ -69,7 +61,12 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
   const [error, setError] = useState<string | null>(null);
   const [focusFilter, setFocusFilter] = useState<TherapistFocusArea | 'all'>('all');
 
+  // Two separate interfaces: the open 公開問答 browse (default — the showcase /
+  // funnel) and the 找諮商師 directory where you book a (free) chat.
+  const [tab, setTab] = useState<'qa' | 'directory'>('qa');
+
   const [bookingTarget, setBookingTarget] = useState<Therapist | null>(null);
+  const [profileTarget, setProfileTarget] = useState<Therapist | null>(null);
   const [showMine, setShowMine] = useState(false);
   const [chatTarget, setChatTarget] = useState<TherapistConsultation | null>(null);
   const [consultations, setConsultations] = useState<TherapistConsultation[]>([]);
@@ -79,6 +76,7 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
   // can offer a "我的諮商師檔案" editor.
   const [ownProfile, setOwnProfile] = useState<OwnTherapistProfile | null>(null);
   const [showProfileEditor, setShowProfileEditor] = useState(false);
+  const [showEarnings, setShowEarnings] = useState(false);
 
   const loadOwnProfile = useCallback(async () => {
     if (!authState.isAuthenticated) { setOwnProfile(null); return; }
@@ -154,6 +152,40 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
         </div>
       </div>
 
+      {/* Mode tabs: 公開問答 (browse) vs 找諮商師 (directory + free chat) */}
+      <div className="flex justify-center">
+        <div className="inline-flex p-1 rounded-full bg-petal-cream-2 border border-petal-rule">
+          <button
+            onClick={() => setTab('qa')}
+            data-testid="therapist-tab-qa"
+            className={`inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full font-body text-[13px] font-medium transition-colors ${
+              tab === 'qa' ? 'bg-petal-ink text-petal-cream' : 'text-petal-ink-soft hover:text-petal-ink'
+            }`}
+          >
+            <Globe className="w-3.5 h-3.5" strokeWidth={1.5} /> 公開問答
+          </button>
+          <button
+            onClick={() => setTab('directory')}
+            data-testid="therapist-tab-directory"
+            className={`inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full font-body text-[13px] font-medium transition-colors ${
+              tab === 'directory' ? 'bg-petal-ink text-petal-cream' : 'text-petal-ink-soft hover:text-petal-ink'
+            }`}
+          >
+            <Users className="w-3.5 h-3.5" strokeWidth={1.5} /> 找諮商師
+          </button>
+        </div>
+      </div>
+
+      {tab === 'qa' && (
+        <PublicQaView
+          isAuthenticated={authState.isAuthenticated}
+          showNotification={showNotification}
+          onFindTherapist={() => setTab('directory')}
+        />
+      )}
+
+      {tab === 'directory' && (
+      <>
       {/* Actions row */}
       <div className="flex flex-wrap items-center justify-center gap-2">
         {/* Sign-up is a public, no-login page (served by the backend at
@@ -184,6 +216,16 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
           >
             <UserCog className="w-3.5 h-3.5" strokeWidth={1.5} />
             我的諮商師檔案
+          </button>
+        )}
+        {authState.isAuthenticated && ownProfile && (
+          <button
+            onClick={() => setShowEarnings(true)}
+            data-testid="therapist-earnings-button"
+            className="flex items-center gap-1.5 px-4 py-2 rounded-full border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors font-body text-[13px] font-medium"
+          >
+            <Wallet className="w-3.5 h-3.5" strokeWidth={1.5} />
+            我的收入
           </button>
         )}
       </div>
@@ -227,9 +269,16 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
           {therapists.map((t) => (
-            <TherapistCard key={t.id} therapist={t} onBook={() => setBookingTarget(t)} />
+            <TherapistCard
+              key={t.id}
+              therapist={t}
+              onBook={() => setBookingTarget(t)}
+              onViewProfile={() => setProfileTarget(t)}
+            />
           ))}
         </div>
+      )}
+      </>
       )}
 
       {bookingTarget && (
@@ -252,11 +301,23 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
         />
       )}
 
+      {profileTarget && (
+        <TherapistProfileModal
+          therapist={profileTarget}
+          isAuthenticated={authState.isAuthenticated}
+          onClose={() => setProfileTarget(null)}
+          onBook={() => { const t = profileTarget; setProfileTarget(null); setBookingTarget(t); }}
+          showNotification={showNotification}
+        />
+      )}
+
       {showMine && (
         <MyConsultationsModal
           consultations={consultations}
           onClose={() => setShowMine(false)}
           onOpenRoom={(c) => setChatTarget(c)}
+          onChanged={loadConsultations}
+          showNotification={showNotification}
         />
       )}
 
@@ -266,6 +327,10 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
           onClose={() => { setChatTarget(null); setConsultationsLoaded(false); loadConsultations(); }}
           showNotification={showNotification}
         />
+      )}
+
+      {showEarnings && (
+        <EarningsModal onClose={() => setShowEarnings(false)} showNotification={showNotification} />
       )}
 
       {showProfileEditor && ownProfile && (
@@ -284,27 +349,9 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
   );
 };
 
-// --- Filter chip ----------------------------------------------------------
-
-const FilterChip: React.FC<{ active: boolean; onClick: () => void; label: string; emoji: string }> = ({
-  active, onClick, label, emoji,
-}) => (
-  <button
-    onClick={onClick}
-    className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-full transition-colors border font-body text-[13px] font-medium tracking-tight ${
-      active
-        ? 'bg-petal-ink text-petal-cream border-petal-ink'
-        : 'bg-transparent text-petal-ink-soft border-petal-rule hover:border-petal-ink hover:text-petal-ink'
-    }`}
-  >
-    <span>{emoji}</span>
-    <span>{label}</span>
-  </button>
-);
-
 // --- Therapist card -------------------------------------------------------
 
-const TherapistCard: React.FC<{ therapist: Therapist; onBook: () => void }> = ({ therapist, onBook }) => (
+const TherapistCard: React.FC<{ therapist: Therapist; onBook: () => void; onViewProfile: () => void }> = ({ therapist, onBook, onViewProfile }) => (
   <div
     className="flex flex-col bg-petal-cream rounded-lg border border-petal-rule shadow-petal overflow-hidden"
     data-testid="therapist-card"
@@ -377,13 +424,22 @@ const TherapistCard: React.FC<{ therapist: Therapist; onBook: () => void }> = ({
         <span className="font-display text-lg text-pink-600">{formatNtd(therapist.rateTwd)}</span>
         <span className="text-petal-muted text-xs"> / {therapist.sessionMinutes} 分鐘</span>
       </div>
-      <button
-        onClick={onBook}
-        data-testid="therapist-book-button"
-        className="px-4 py-2 rounded-full bg-pink-500 text-white hover:bg-pink-600 transition-colors font-body text-[13px] font-medium"
-      >
-        預約諮詢
-      </button>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onViewProfile}
+          data-testid="therapist-profile-button"
+          className="px-3.5 py-2 rounded-full border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink transition-colors font-body text-[13px] font-medium"
+        >
+          完整檔案
+        </button>
+        <button
+          onClick={onBook}
+          data-testid="therapist-book-button"
+          className="px-4 py-2 rounded-full bg-pink-500 text-white hover:bg-pink-600 transition-colors font-body text-[13px] font-medium"
+        >
+          預約諮詢
+        </button>
+      </div>
     </div>
   </div>
 );
@@ -532,7 +588,9 @@ const MyConsultationsModal: React.FC<{
   consultations: TherapistConsultation[];
   onClose: () => void;
   onOpenRoom: (c: TherapistConsultation) => void;
-}> = ({ consultations, onClose, onOpenRoom }) => (
+  onChanged: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ consultations, onClose, onOpenRoom, onChanged, showNotification }) => (
   <ModalShell title="我的預約" onClose={onClose}>
     {consultations.length === 0 ? (
       <p className="font-body text-sm text-petal-muted py-6 text-center">
@@ -542,6 +600,7 @@ const MyConsultationsModal: React.FC<{
       <div className="space-y-3" data-testid="my-consultations">
         {consultations.map((c) => {
           const status = CONSULTATION_STATUS[c.status];
+          const isPaidSession = c.bookingType === 'scheduled';
           return (
             <div key={c.id} className="rounded-md border border-petal-rule p-4" data-testid="consultation-row">
               <div className="flex items-center justify-between gap-2">
@@ -558,6 +617,19 @@ const MyConsultationsModal: React.FC<{
                 </div>
                 <span className={`font-body text-xs font-medium ${status.cls}`}>{status.label}</span>
               </div>
+              {isPaidSession && (
+                <div className="mt-1 inline-flex items-center gap-1.5 font-body text-[11px]">
+                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-pink-50 border border-pink-200 text-pink-700">
+                    <Video className="w-3 h-3" strokeWidth={1.5} /> 視訊諮商
+                  </span>
+                  {c.paymentStatus && (
+                    <span className={c.paymentStatus === 'paid' ? 'text-petal-sage-deep' : 'text-petal-muted'}>
+                      {PAYMENT_STATUS_LABEL[c.paymentStatus]}
+                      {c.priceTwd ? ` · ${formatNtd(c.priceTwd)}` : ''}
+                    </span>
+                  )}
+                </div>
+              )}
               {c.focusArea && (
                 <div className="mt-1 font-body text-xs text-petal-ink-soft">
                   主題：{focusLabel(c.focusArea)}
@@ -577,6 +649,16 @@ const MyConsultationsModal: React.FC<{
                   諮商師回覆：{c.responseNote}
                 </p>
               )}
+              {c.publicStatus && c.publicStatus !== 'private' && c.publicStatus !== 'withdrawn' && (
+                <div className="mt-2 inline-flex items-center gap-1 font-body text-[11px] text-petal-ink-soft">
+                  <Globe className="w-3 h-3" strokeWidth={1.5} />
+                  {PUBLIC_STATUS_LABEL[c.publicStatus]}
+                </div>
+              )}
+
+              {/* Paid-session actions (pay / accept / meeting link / complete) */}
+              <ConsultationSessionActions c={c} onChanged={onChanged} showNotification={showNotification} />
+
               <button
                 onClick={() => onOpenRoom(c)}
                 data-testid="enter-room-button"
@@ -592,6 +674,364 @@ const MyConsultationsModal: React.FC<{
     )}
   </ModalShell>
 );
+
+// Paid-video-session actions on a consultation row: the client pays / joins; the
+// therapist accepts, sets the meeting link, and completes / marks no-show.
+const ConsultationSessionActions: React.FC<{
+  c: TherapistConsultation;
+  onChanged: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ c, onChanged, showNotification }) => {
+  const [busy, setBusy] = useState(false);
+  const [provider, setProvider] = useState<MeetingProvider>('meet');
+  const [url, setUrl] = useState('');
+
+  if (c.bookingType !== 'scheduled') return null;
+
+  const notifyErr = (err: unknown) =>
+    showNotification({ type: 'error', title: '操作失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 4000 });
+
+  const pay = async () => {
+    try { setBusy(true); await apiService.paySession(c.id); } catch (err) { notifyErr(err); setBusy(false); }
+  };
+  const respond = async (action: 'accept' | 'decline' | 'complete' | 'no_show') => {
+    try {
+      setBusy(true);
+      await apiService.respondConsultation(c.id, action);
+      onChanged();
+    } catch (err) { notifyErr(err); } finally { setBusy(false); }
+  };
+  const saveMeeting = async () => {
+    if (!url.trim()) return;
+    try {
+      setBusy(true);
+      await apiService.setMeetingLink(c.id, provider, url.trim());
+      setUrl('');
+      onChanged();
+      showNotification({ type: 'success', title: '已設定會議連結', message: '對方付款後即可看到連結', duration: 3000 });
+    } catch (err) { notifyErr(err); } finally { setBusy(false); }
+  };
+
+  // --- Client side ---
+  if (c.role === 'client') {
+    if (c.paymentStatus === 'unpaid' || c.paymentStatus === 'failed') {
+      return (
+        <button onClick={pay} disabled={busy} data-testid="pay-session-button"
+          className="mt-3 mr-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-pink-500 text-white hover:bg-pink-600 disabled:opacity-50 transition-colors font-body text-xs font-medium">
+          <Wallet className="w-3.5 h-3.5" strokeWidth={1.5} /> {busy ? '前往付款…' : `前往付款 ${c.priceTwd ? formatNtd(c.priceTwd) : ''}`}
+        </button>
+      );
+    }
+    if (c.paymentStatus === 'pending') {
+      return <p className="mt-2 font-body text-xs text-petal-muted">付款確認中，稍候會自動更新。</p>;
+    }
+    if (c.paymentStatus === 'paid') {
+      return c.meetingUrl ? (
+        <a href={c.meetingUrl} target="_blank" rel="noopener noreferrer" data-testid="join-meeting-link"
+          className="mt-3 mr-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-petal-sage-deep text-white hover:opacity-90 transition-opacity font-body text-xs font-medium">
+          <Video className="w-3.5 h-3.5" strokeWidth={1.5} /> 加入{MEETING_LABEL[c.meetingProvider || 'other']}視訊
+        </a>
+      ) : (
+        <p className="mt-2 font-body text-xs text-petal-sage-deep">已付款，等待諮商師提供會議連結。</p>
+      );
+    }
+    return null;
+  }
+
+  // --- Therapist side ---
+  if (c.role === 'therapist') {
+    if (c.status === 'pending') {
+      return (
+        <div className="mt-3 flex items-center gap-2">
+          <button onClick={() => respond('accept')} disabled={busy} data-testid="accept-booking"
+            className="px-3 py-1.5 rounded-full bg-pink-500 text-white hover:bg-pink-600 disabled:opacity-50 font-body text-xs font-medium">接受預約</button>
+          <button onClick={() => respond('decline')} disabled={busy}
+            className="px-3 py-1.5 rounded-full border border-petal-rule text-petal-ink-soft hover:border-petal-ink font-body text-xs">婉拒</button>
+        </div>
+      );
+    }
+    if (c.status === 'accepted') {
+      return (
+        <div className="mt-3 space-y-2">
+          {c.meetingUrl ? (
+            <div className="inline-flex items-center gap-1.5 font-body text-xs text-petal-sage-deep">
+              <Video className="w-3.5 h-3.5" strokeWidth={1.5} /> 會議連結已提供（{MEETING_LABEL[c.meetingProvider || 'other']}）
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              <select value={provider} onChange={(e) => setProvider(e.target.value as MeetingProvider)} className="px-2 py-1.5 rounded-md border border-petal-rule bg-petal-cream font-body text-xs text-petal-ink">
+                <option value="meet">Google Meet</option>
+                <option value="zoom">Zoom</option>
+                <option value="other">其他</option>
+              </select>
+              <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="貼上會議連結 https://…" data-testid="meeting-link-input"
+                className="flex-1 min-w-[180px] px-3 py-1.5 rounded-md border border-petal-rule bg-petal-cream focus:border-petal-ink focus:outline-none font-body text-xs text-petal-ink" />
+              <button onClick={saveMeeting} disabled={busy || !url.trim()} data-testid="save-meeting-link"
+                className="px-3 py-1.5 rounded-full bg-petal-ink text-petal-cream hover:bg-pink-700 disabled:opacity-50 font-body text-xs font-medium">設定連結</button>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <button onClick={() => respond('complete')} disabled={busy} data-testid="complete-booking"
+              className="px-3 py-1.5 rounded-full border border-petal-sage text-petal-sage-deep hover:bg-petal-sage/10 disabled:opacity-50 font-body text-xs">標記完成</button>
+            <button onClick={() => respond('no_show')} disabled={busy}
+              className="px-3 py-1.5 rounded-full border border-petal-rule text-petal-muted hover:border-petal-ink font-body text-xs">未出席</button>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
+  return null;
+};
+
+// --- Paid video session: booking modal + helpers -------------------------
+
+const PAYMENT_STATUS_LABEL: Record<NonNullable<TherapistConsultation['paymentStatus']>, string> = {
+  unpaid: '尚未付款',
+  pending: '付款確認中',
+  paid: '已付款',
+  refunded: '已退款',
+  failed: '付款失敗',
+};
+
+const MEETING_LABEL: Record<string, string> = { zoom: 'Zoom', meet: 'Google Meet', other: '視訊' };
+
+// Books a paid video session off a free chat, then redirects to ECPay. Video is
+// third-party; the platform only matches the two parties.
+const VideoBookingModal: React.FC<{
+  therapistId: string;
+  therapistName: string;
+  priceTwd: number;
+  sessionMinutes: number;
+  sourceConsultationId?: string;
+  onClose: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ therapistId, therapistName, priceTwd, sessionMinutes, sourceConsultationId, onClose, showNotification }) => {
+  const [message, setMessage] = useState('');
+  const [preferredTime, setPreferredTime] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const proceed = async () => {
+    try {
+      setBusy(true);
+      const booking = await apiService.bookVideoSession(therapistId, {
+        message: message.trim() || undefined,
+        preferredTime: preferredTime ? new Date(preferredTime).toISOString() : undefined,
+        sourceConsultationId,
+      });
+      // Redirects the browser to ECPay (resolves only on failure to start).
+      await apiService.paySession(booking.id);
+    } catch (err) {
+      showNotification({ type: 'error', title: '預約失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 4000 });
+      setBusy(false);
+    }
+  };
+
+  return (
+    <ModalShell title={`預約視訊諮商 · ${therapistName}`} onClose={onClose}>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between rounded-md bg-petal-cream-2 border border-petal-rule px-4 py-3">
+          <span className="font-body text-sm text-petal-ink-soft">1:1 視訊諮商 · {sessionMinutes} 分鐘</span>
+          <span className="font-display text-lg text-pink-600">{formatNtd(priceTwd)}</span>
+        </div>
+        <p className="font-body text-xs text-petal-muted">
+          視訊以 Zoom / Google Meet 進行，諮商師接受預約後會提供會議連結。付款由綠界（ECPay）處理。
+        </p>
+        <div>
+          <label className={fieldLabel}>希望的時段（選填）</label>
+          <input type="datetime-local" value={preferredTime} onChange={(e) => setPreferredTime(e.target.value)} className={fieldInput} />
+        </div>
+        <div>
+          <label className={fieldLabel}>想先讓諮商師知道的事（選填）</label>
+          <textarea value={message} onChange={(e) => setMessage(e.target.value)} rows={3} maxLength={2000} className={`${fieldInput} resize-none`} />
+        </div>
+        <button
+          onClick={proceed}
+          disabled={busy}
+          data-testid="video-pay-button"
+          className="w-full py-3 rounded-md bg-petal-ink text-petal-cream hover:bg-pink-700 disabled:opacity-50 transition-colors font-display italic text-base"
+        >
+          {busy ? '前往付款…' : `前往付款 ${formatNtd(priceTwd)}`}
+        </button>
+      </div>
+    </ModalShell>
+  );
+};
+
+// --- 公開問答 publish controls (inside the chat room) ---------------------
+
+// The two-party consent handshake to publish a chat as 公開問答. Either side may
+// propose (with an anonymised title); the OTHER side approves; either side can
+// withdraw. We infer "did I propose this?" from the publish status + my role,
+// which is enough because the therapist and the couple are the two sides.
+const PublishControls: React.FC<{
+  consultationId: string;
+  status: ConsultationPublicStatus;
+  role: 'therapist' | 'client';
+  onChanged: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ consultationId, status, role, onChanged, showNotification }) => {
+  const [proposing, setProposing] = useState(false);
+  const [titleDraft, setTitleDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const canPropose = status === 'private' || status === 'withdrawn';
+  const iRequested =
+    (status === 'client_requested' && role === 'client') ||
+    (status === 'therapist_requested' && role === 'therapist');
+  const iCanApprove =
+    (status === 'client_requested' && role === 'therapist') ||
+    (status === 'therapist_requested' && role === 'client');
+  const published = status === 'published';
+
+  const run = async (fn: () => Promise<{ message: string }>) => {
+    try {
+      setBusy(true);
+      const res = await fn();
+      onChanged();
+      setProposing(false);
+      setTitleDraft('');
+      showNotification({ type: 'success', title: '已更新', message: res.message, duration: 3500 });
+    } catch (err) {
+      showNotification({ type: 'error', title: '操作失敗', message: err instanceof Error ? err.message : '請稍後再試', duration: 3500 });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="px-5 py-2.5 border-b border-petal-rule bg-petal-cream-2/60" data-testid="publish-controls">
+      {proposing ? (
+        <div className="space-y-2">
+          <p className="font-body text-[11px] text-petal-muted">
+            匿名公開這段對話，幫助有相同困擾的人。對方同意後才會公開，個案姓名不會顯示。
+          </p>
+          <div className="flex items-center gap-2">
+            <input
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              maxLength={200}
+              placeholder="幫這則公開問答下個標題…"
+              data-testid="publish-title-input"
+              className="flex-1 px-3 py-1.5 rounded-full border border-petal-rule bg-petal-cream focus:border-petal-ink focus:outline-none font-body text-sm text-petal-ink"
+            />
+            <button
+              onClick={() => run(() => apiService.requestPublishConsultation(consultationId, titleDraft.trim()))}
+              disabled={busy || !titleDraft.trim()}
+              data-testid="publish-submit"
+              className="shrink-0 px-3 py-1.5 rounded-full bg-petal-ink text-petal-cream hover:bg-pink-700 disabled:opacity-40 font-body text-xs font-medium"
+            >
+              送出提議
+            </button>
+            <button onClick={() => { setProposing(false); setTitleDraft(''); }} className="shrink-0 text-petal-muted hover:text-petal-ink font-body text-xs">
+              取消
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-2">
+          <div className="inline-flex items-center gap-1.5 font-body text-[11px] text-petal-ink-soft min-w-0">
+            <Globe className="w-3 h-3 shrink-0" strokeWidth={1.5} />
+            <span className="truncate">{PUBLIC_STATUS_LABEL[status]}</span>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {canPropose && (
+              <button onClick={() => setProposing(true)} data-testid="publish-propose" className="font-body text-xs font-medium text-petal-ink underline underline-offset-2 hover:text-pink-700">
+                設為公開問答
+              </button>
+            )}
+            {iRequested && (
+              <button onClick={() => run(() => apiService.withdrawPublishConsultation(consultationId))} disabled={busy} className="font-body text-xs text-petal-muted hover:text-petal-ink disabled:opacity-40">
+                取消提議
+              </button>
+            )}
+            {iCanApprove && (
+              <>
+                <button onClick={() => run(() => apiService.approvePublishConsultation(consultationId))} disabled={busy} data-testid="publish-approve" className="px-3 py-1 rounded-full bg-pink-500 text-white hover:bg-pink-600 disabled:opacity-40 font-body text-xs font-medium">
+                  同意公開
+                </button>
+                <button onClick={() => run(() => apiService.withdrawPublishConsultation(consultationId))} disabled={busy} className="font-body text-xs text-petal-muted hover:text-petal-ink disabled:opacity-40">
+                  婉拒
+                </button>
+              </>
+            )}
+            {published && (
+              <button onClick={() => run(() => apiService.withdrawPublishConsultation(consultationId))} disabled={busy} data-testid="publish-withdraw" className="font-body text-xs text-petal-muted hover:text-petal-ink disabled:opacity-40">
+                取消公開
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// --- Therapist earnings ---------------------------------------------------
+
+const EarningsModal: React.FC<{
+  onClose: () => void;
+  showNotification: (n: Omit<Notification, 'id'>) => void;
+}> = ({ onClose, showNotification }) => {
+  const [earnings, setEarnings] = useState<TherapistEarnings | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    apiService.getMyEarnings()
+      .then((e) => { if (alive) setEarnings(e); })
+      .catch((err) => { if (alive) showNotification({ type: 'error', title: '無法取得收入', message: err instanceof Error ? err.message : '請稍後再試', duration: 4000 }); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [showNotification]);
+
+  return (
+    <ModalShell title="我的收入" onClose={onClose}>
+      {loading ? (
+        <p className="font-body text-sm text-petal-muted py-6 text-center">載入中…</p>
+      ) : !earnings ? (
+        <p className="font-body text-sm text-petal-muted py-6 text-center">尚無收入資料。</p>
+      ) : (
+        <div className="space-y-4" data-testid="earnings-modal">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-md border border-petal-rule p-4">
+              <div className="font-body text-xs text-petal-muted">累計實拿</div>
+              <div className="font-display text-2xl text-pink-600">{formatNtd(earnings.totalNetTwd)}</div>
+              <div className="font-body text-[11px] text-petal-muted mt-0.5">{earnings.paidSessionCount} 次已付款諮商</div>
+            </div>
+            <div className="rounded-md border border-petal-rule p-4">
+              <div className="font-body text-xs text-petal-muted">目前平台分潤</div>
+              <div className="font-display text-2xl text-petal-ink">{earnings.currentFeeRate}%</div>
+              <div className="font-body text-[11px] text-petal-muted mt-0.5">
+                {earnings.introSessionsRemaining > 0
+                  ? `新進優惠剩 ${earnings.introSessionsRemaining} 次（10%）`
+                  : '已套用一般分潤（20%）'}
+              </div>
+            </div>
+          </div>
+          <p className="font-body text-[11px] text-petal-muted">
+            視訊諮商款項由平台每月結算後撥付。問答分潤另計（每月結算）。
+          </p>
+          {earnings.sessions.length > 0 && (
+            <div className="space-y-2">
+              <div className="font-body text-xs font-semibold text-petal-ink-soft">已付款的諮商</div>
+              {earnings.sessions.map((s) => (
+                <div key={s.id} className="flex items-center justify-between rounded-md border border-petal-rule px-3 py-2 font-body text-xs">
+                  <span className="text-petal-muted">
+                    {s.paidAt ? new Date(s.paidAt).toLocaleDateString('zh-TW') : '—'} · 平台 {s.feeRate}%
+                  </span>
+                  <span className="text-petal-ink">
+                    {formatNtd(s.priceTwd)} → <span className="text-pink-600 font-medium">實拿 {formatNtd(s.therapistNetTwd)}</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </ModalShell>
+  );
+};
 
 // --- Consultation chat room ----------------------------------------------
 
@@ -609,6 +1049,7 @@ const ChatRoom: React.FC<{
   const [selectedEvent, setSelectedEvent] = useState<EventRecord | null>(null);
   const [showEventPicker, setShowEventPicker] = useState(false);
   const [sending, setSending] = useState(false);
+  const [showBooking, setShowBooking] = useState(false);
   const endRef = useRef<HTMLDivElement | null>(null);
 
   const load = useCallback(async () => {
@@ -619,6 +1060,12 @@ const ChatRoom: React.FC<{
       console.error('Failed to load thread:', err);
     }
   }, [consultation.id]);
+
+  // The "預約視訊諮商" nudge is for the client side, and only when we know the
+  // therapist + their rate (from the consultation list payload).
+  const canBookVideo = consultation.role === 'client'
+    && !!consultation.therapistId
+    && typeof consultation.therapistRateTwd === 'number';
 
   useEffect(() => {
     load();
@@ -677,6 +1124,29 @@ const ChatRoom: React.FC<{
             <X className="w-5 h-5" strokeWidth={1.5} />
           </button>
         </div>
+
+        {/* 公開問答 publish handshake */}
+        {thread && (
+          <PublishControls
+            consultationId={consultation.id}
+            status={thread.publicStatus || 'private'}
+            role={thread.role}
+            onChanged={load}
+            showNotification={showNotification}
+          />
+        )}
+
+        {/* Nudge to book a paid video session (the free chat funnel) */}
+        {canBookVideo && (
+          <button
+            onClick={() => setShowBooking(true)}
+            data-testid="book-video-cta"
+            className="flex items-center justify-center gap-2 px-5 py-2.5 border-b border-petal-rule bg-pink-50 text-pink-700 hover:bg-pink-100 transition-colors font-body text-[13px] font-medium"
+          >
+            <Video className="w-3.5 h-3.5" strokeWidth={1.5} />
+            想更深入談談？預約 1:1 視訊諮商（{formatNtd(consultation.therapistRateTwd || 0)} / {consultation.therapistSessionMinutes || 50} 分鐘）
+          </button>
+        )}
 
         {/* Messages */}
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3" data-testid="chat-messages">
@@ -759,6 +1229,19 @@ const ChatRoom: React.FC<{
         </div>
       </div>
 
+      {/* Paid video booking */}
+      {showBooking && canBookVideo && (
+        <VideoBookingModal
+          therapistId={consultation.therapistId as string}
+          therapistName={consultation.therapistName}
+          priceTwd={consultation.therapistRateTwd as number}
+          sessionMinutes={consultation.therapistSessionMinutes || 50}
+          sourceConsultationId={consultation.id}
+          onClose={() => setShowBooking(false)}
+          showNotification={showNotification}
+        />
+      )}
+
       {/* Event picker overlay */}
       {showEventPicker && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4" onClick={() => setShowEventPicker(false)}>
@@ -833,6 +1316,33 @@ const ProfileEditorModal: React.FC<{
   const [uploadingDoc, setUploadingDoc] = useState(false);
   const [saving, setSaving] = useState(false);
 
+  // Rich profile (048). List fields are edited as one-item-per-line text and
+  // converted on save; publications/articles are "標題 | 連結" per line.
+  const [introMessage, setIntroMessage] = useState(profile.introMessage || '');
+  const [approach, setApproach] = useState(profile.approach || '');
+  const [about, setAbout] = useState(profile.about || '');
+  const [acceptingNewClients, setAcceptingNewClients] = useState(profile.acceptingNewClients !== false);
+  const [certifications, setCertifications] = useState((profile.certifications || []).join('\n'));
+  const [currentPositions, setCurrentPositions] = useState((profile.currentPositions || []).join('\n'));
+  const [qualifications, setQualifications] = useState((profile.qualifications || []).join('\n'));
+  const [training, setTraining] = useState((profile.training || []).join('\n'));
+  const [publications, setPublications] = useState(
+    (profile.publications || []).map((p) => (p.source ? `${p.title} | ${p.source}` : p.title)).join('\n')
+  );
+  const [articles, setArticles] = useState(
+    (profile.articles || []).map((a) => (a.url ? `${a.title} | ${a.url}` : a.title)).join('\n')
+  );
+
+  // "one per line" → string[]; "標題 | 連結" → {title, [key]} list.
+  const linesToList = (raw: string): string[] =>
+    raw.split('\n').map((l) => l.trim()).filter(Boolean);
+  const linesToLinks = (raw: string, key: 'url' | 'source') =>
+    raw.split('\n').map((l) => l.trim()).filter(Boolean).map((line) => {
+      const [title, ...rest] = line.split('|');
+      const link = rest.join('|').trim();
+      return { title: title.trim(), [key]: link } as { title: string; url?: string; source?: string };
+    }).filter((it) => it.title);
+
   const toggleFocus = (id: TherapistFocusArea) => {
     setFocusAreas((prev) => (prev.includes(id) ? prev.filter((f) => f !== id) : [...prev, id]));
   };
@@ -890,6 +1400,17 @@ const ProfileEditorModal: React.FC<{
       sessionMinutes: Number(sessionMinutes) || 50,
       yearsExperience: yearsExperience ? Number(yearsExperience) : null,
       contactPhone: contactPhone.trim() || null,
+      // Rich profile sections (048).
+      introMessage: introMessage.trim() || null,
+      approach: approach.trim() || null,
+      about: about.trim() || null,
+      acceptingNewClients,
+      certifications: linesToList(certifications),
+      currentPositions: linesToList(currentPositions),
+      qualifications: linesToList(qualifications),
+      training: linesToList(training),
+      publications: linesToLinks(publications, 'source'),
+      articles: linesToLinks(articles, 'url'),
     };
     try {
       setSaving(true);
@@ -1036,6 +1557,54 @@ const ProfileEditorModal: React.FC<{
         <div>
           <label className={fieldLabel}>自我介紹</label>
           <textarea value={bio} onChange={(e) => setBio(e.target.value)} rows={4} maxLength={2000} className={`${fieldInput} resize-none`} />
+        </div>
+
+        {/* Rich profile sections (048) */}
+        <div className="pt-1 border-t border-petal-rule">
+          <div className="font-body text-xs font-semibold text-petal-ink-soft mb-1">完整檔案（選填）</div>
+          <p className="font-body text-[11px] text-petal-muted mb-3">這些內容會顯示在「完整檔案」頁面，幫助來談者更認識你。清單欄位請一行一項。</p>
+        </div>
+
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" checked={acceptingNewClients} onChange={(e) => setAcceptingNewClients(e.target.checked)} className="accent-pink-500" />
+          <span className="font-body text-sm text-petal-ink-soft">目前開放新案預約</span>
+        </label>
+
+        <div>
+          <label className={fieldLabel}>給來談者的一段話</label>
+          <textarea value={introMessage} onChange={(e) => setIntroMessage(e.target.value)} rows={4} maxLength={8000} className={`${fieldInput} resize-y`} placeholder="想對正在考慮預約的人說的話…" />
+        </div>
+        <div>
+          <label className={fieldLabel}>治療取向／治療理念</label>
+          <textarea value={approach} onChange={(e) => setApproach(e.target.value)} rows={4} maxLength={8000} className={`${fieldInput} resize-y`} />
+        </div>
+        <div>
+          <label className={fieldLabel}>認識治療師</label>
+          <textarea value={about} onChange={(e) => setAbout(e.target.value)} rows={3} maxLength={8000} className={`${fieldInput} resize-y`} />
+        </div>
+        <div>
+          <label className={fieldLabel}>心理師證照（一行一項）</label>
+          <textarea value={certifications} onChange={(e) => setCertifications(e.target.value)} rows={2} className={`${fieldInput} resize-y`} placeholder="諮商心理師證書字號／諮心字第 0000 號" />
+        </div>
+        <div>
+          <label className={fieldLabel}>現任（一行一項）</label>
+          <textarea value={currentPositions} onChange={(e) => setCurrentPositions(e.target.value)} rows={2} className={`${fieldInput} resize-y`} />
+        </div>
+        <div>
+          <label className={fieldLabel}>專業資格（一行一項）</label>
+          <textarea value={qualifications} onChange={(e) => setQualifications(e.target.value)} rows={2} className={`${fieldInput} resize-y`} />
+        </div>
+        <div>
+          <label className={fieldLabel}>專業訓練（一行一項）</label>
+          <textarea value={training} onChange={(e) => setTraining(e.target.value)} rows={3} className={`${fieldInput} resize-y`} />
+        </div>
+        <div>
+          <label className={fieldLabel}>心理專業著作（一行一項，可加「標題 | 來源」）</label>
+          <textarea value={publications} onChange={(e) => setPublications(e.target.value)} rows={2} className={`${fieldInput} resize-y`} placeholder="文章標題 | 張老師月刊 No.567" />
+        </div>
+        <div>
+          <label className={fieldLabel}>心理專業文章 / 影音（一行一項，可加「標題 | 連結」）</label>
+          <textarea value={articles} onChange={(e) => setArticles(e.target.value)} rows={3} className={`${fieldInput} resize-y`} placeholder="文章標題 | https://…" />
         </div>
 
         {/* Identity documents */}

--- a/src/components/TherapistsView.tsx
+++ b/src/components/TherapistsView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Heart, Sparkles, X, UserPlus, Clock, Languages, Award, CalendarCheck, MessageCircle, Send, StickyNote, UserCog, Upload, CheckCircle2, AlertCircle, Globe, Users, Video, Wallet } from 'lucide-react';
+import { Heart, X, UserPlus, Clock, Languages, Award, CalendarCheck, MessageCircle, Send, StickyNote, UserCog, Upload, CheckCircle2, AlertCircle, Globe, Users, Video, Wallet } from 'lucide-react';
 import {
   apiService,
   type Therapist,
@@ -142,14 +142,6 @@ const TherapistsView: React.FC<TherapistsViewProps> = ({ authState, showNotifica
         <p className="font-display italic font-light text-base text-petal-muted">
           有些議題值得和一位受過專業訓練的人好好談。選擇一位諮商師，預約屬於你們的對話。
         </p>
-
-        {/* AI rephrase remains the cheaper, always-on option */}
-        <div className="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-full border border-petal-rule bg-petal-cream-2">
-          <Sparkles className="w-3.5 h-3.5 text-pink-500" strokeWidth={1.5} />
-          <span className="font-body text-xs text-petal-ink-soft">
-            只是想換個溫柔的說法？<span className="text-petal-ink">AI 潤稿</span> 仍隨時為你服務，且更省。
-          </span>
-        </div>
       </div>
 
       {/* Mode tabs: 公開問答 (browse) vs 找諮商師 (directory + free chat) */}

--- a/src/components/therapistShared.ts
+++ b/src/components/therapistShared.ts
@@ -1,0 +1,32 @@
+import type { TherapistFocusArea } from '../services/api';
+
+// Shared therapist constants/helpers, used by both TherapistsView (directory +
+// chat) and PublicQaView (公開問答 browse). Kept in their own module so the two
+// views don't import from each other (which would be a circular dependency).
+// Components live in their own files (e.g. FilterChip.tsx) so this module stays
+// HMR-friendly (react-refresh only-export-components).
+
+// Focus areas — value/label/emoji in one place so filter chips, cards, and forms
+// all read from the same source of truth. Order matches the backend FOCUS_AREAS
+// list in routes/therapists.js.
+export const FOCUS_AREAS: { id: TherapistFocusArea; label: string; emoji: string }[] = [
+  { id: 'couple', label: '伴侶關係', emoji: '💞' },
+  { id: 'family', label: '家庭', emoji: '🏡' },
+  { id: 'childhood', label: '童年/原生家庭', emoji: '🧸' },
+  { id: 'individual', label: '個人成長', emoji: '🌱' },
+  { id: 'sexuality', label: '性與親密', emoji: '🔥' },
+  { id: 'parenting', label: '親職教養', emoji: '👶' },
+  { id: 'grief', label: '悲傷失落', emoji: '🕊️' },
+  { id: 'anxiety', label: '焦慮憂鬱', emoji: '🌧️' },
+  { id: 'depression', label: '憂鬱情緒', emoji: '🌫️' },
+  { id: 'trauma', label: '創傷', emoji: '💔' },
+  { id: 'addiction', label: '成癮', emoji: '🎯' },
+  { id: 'lgbtq', label: '性別與多元認同', emoji: '🏳️‍🌈' },
+  { id: 'career', label: '職涯/工作壓力', emoji: '💼' },
+  { id: 'self_esteem', label: '自我價值', emoji: '✨' },
+];
+
+export const focusLabel = (id: string): string =>
+  FOCUS_AREAS.find((f) => f.id === id)?.label || id;
+
+export const formatNtd = (n: number): string => `NT$${n.toLocaleString('en-US')}`;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -681,6 +681,13 @@ export type TherapistFocusArea =
 
 export type TherapistIdentityStatus = 'unverified' | 'submitted' | 'verified' | 'rejected';
 
+// Title + optional link, used by publications (source) and articles (url).
+export interface TherapistLinkItem {
+  title: string;
+  url?: string;
+  source?: string;
+}
+
 export interface Therapist {
   id: string;
   displayName: string;
@@ -694,7 +701,33 @@ export interface Therapist {
   rateTwd: number;
   sessionMinutes: number;
   identityStatus?: TherapistIdentityStatus;
+  // Rich profile sections (migration 048).
+  introMessage?: string | null;
+  approach?: string | null;
+  about?: string | null;
+  certifications?: string[];
+  currentPositions?: string[];
+  qualifications?: string[];
+  training?: string[];
+  publications?: TherapistLinkItem[];
+  articles?: TherapistLinkItem[];
+  acceptingNewClients?: boolean;
   createdAt: string;
+}
+
+export interface TherapistReview {
+  id: string;
+  reviewerDisplay: string;
+  rating?: number | null;
+  body: string;
+  createdAt: string;
+}
+
+export interface TherapistReviewsResult {
+  summary: { count: number; avgRating: number | null };
+  canReview: boolean;
+  alreadyReviewed: boolean;
+  reviews: TherapistReview[];
 }
 
 // The therapist's own private view of their profile (GET /therapists/me).
@@ -739,6 +772,17 @@ export interface TherapistProfileUpdate {
   rateTwd?: number;
   sessionMinutes?: number;
   contactPhone?: string | null;
+  // Rich profile sections (048).
+  introMessage?: string | null;
+  approach?: string | null;
+  about?: string | null;
+  certifications?: string[];
+  currentPositions?: string[];
+  qualifications?: string[];
+  training?: string[];
+  publications?: TherapistLinkItem[];
+  articles?: TherapistLinkItem[];
+  acceptingNewClients?: boolean;
 }
 
 export interface ConsultationRequestInput {
@@ -748,20 +792,55 @@ export interface ConsultationRequestInput {
   preferredTime?: string;
 }
 
+// 公開問答 publish lifecycle. private → (client|therapist)_requested → published,
+// or withdrawn. See migration 045 + routes/therapists.js publish handshake.
+export type ConsultationPublicStatus =
+  | 'private' | 'client_requested' | 'therapist_requested' | 'published' | 'withdrawn';
+
 export interface TherapistConsultation {
   id: string;
+  therapistId?: string;
   therapistName: string;
   therapistTitle?: string | null;
+  therapistRateTwd?: number;
+  therapistSessionMinutes?: number;
   requesterName?: string | null;
   role: 'therapist' | 'client';
   focusArea?: TherapistFocusArea | null;
   message?: string | null;
   preferredTime?: string | null;
-  status: 'pending' | 'accepted' | 'declined' | 'completed' | 'cancelled';
+  status: 'pending' | 'accepted' | 'declined' | 'completed' | 'cancelled' | 'no_show';
   respondedAt?: string | null;
   responseNote?: string | null;
+  publicStatus?: ConsultationPublicStatus;
+  publicTitle?: string | null;
+  // Paid video session (046). bookingType 'free' = the no-charge chat.
+  bookingType?: 'free' | 'scheduled';
+  paymentStatus?: 'unpaid' | 'pending' | 'paid' | 'refunded' | 'failed';
+  priceTwd?: number | null;
+  meetingProvider?: 'zoom' | 'meet' | 'other' | null;
+  meetingUrl?: string | null; // only present once paid
   messageCount: number;
   createdAt: string;
+}
+
+export type MeetingProvider = 'zoom' | 'meet' | 'other';
+
+export interface TherapistEarnings {
+  introSessionsUsed: number;
+  introSessionsRemaining: number;
+  currentFeeRate: number;
+  paidSessionCount: number;
+  totalNetTwd: number;
+  sessions: {
+    id: string;
+    priceTwd: number;
+    feeRate: number;
+    platformFeeTwd: number;
+    therapistNetTwd: number;
+    paidAt: string | null;
+    status: string;
+  }[];
 }
 
 export interface ConsultationMessage {
@@ -779,7 +858,47 @@ export interface ConsultationThread {
   role: 'therapist' | 'client';
   therapistName: string;
   currentUserId: string;
+  publicStatus?: ConsultationPublicStatus;
+  publicTitle?: string | null;
   messages: ConsultationMessage[];
+}
+
+// --- 公開問答 (Public Q&A) read-only browse types ---
+
+export interface PublicQaThreadSummary {
+  id: string;
+  title: string;
+  focusArea?: TherapistFocusArea | null;
+  publishedAt: string;
+  therapist: { id: string; displayName: string; title?: string | null; photoUrl?: string | null };
+  preview: string;
+  messageCount: number;
+  helpfulCount: number;
+}
+
+export interface PublicQaMessage {
+  id: string;
+  body: string;
+  createdAt: string;
+  isTherapist: boolean;
+  senderName: string; // therapist name, or "匿名個案"
+}
+
+export interface PublicQaThread {
+  id: string;
+  title: string;
+  focusArea?: TherapistFocusArea | null;
+  publishedAt: string;
+  helpfulCount: number;
+  hasVoted: boolean;
+  therapist: { id: string; displayName: string; title?: string | null; photoUrl?: string | null };
+  messages: PublicQaMessage[];
+}
+
+export interface PublicQaListResult {
+  page: number;
+  hasMore: boolean;
+  threads: PublicQaThreadSummary[];
 }
 
 // API Service Class
@@ -2550,6 +2669,8 @@ class ApiService {
         role: d.role,
         therapistName: d.therapistName,
         currentUserId: d.currentUserId,
+        publicStatus: d.publicStatus,
+        publicTitle: d.publicTitle,
         messages: (d.messages || []) as ConsultationMessage[],
       };
     } catch (error: unknown) {
@@ -2567,6 +2688,171 @@ class ApiService {
     } catch (error: unknown) {
       console.error('Failed to post consultation message:', error);
       this.throwApiError(error, '送出訊息失敗');
+    }
+  }
+
+  // --- 公開問答 (Public Q&A) ---
+
+  // Propose publishing a consultation chat. The other party must approve.
+  async requestPublishConsultation(consultationId: string, title: string): Promise<{ publicStatus: ConsultationPublicStatus; message: string }> {
+    try {
+      const response = await apiClient.post(`/therapists/consultations/${consultationId}/publish-request`, { title });
+      return { publicStatus: response.data?.publicStatus, message: response.data?.message };
+    } catch (error: unknown) {
+      console.error('Failed to request publish:', error);
+      this.throwApiError(error, '提議公開失敗，請稍後再試');
+    }
+  }
+
+  // Consent to a pending publish proposal (must be the other party).
+  async approvePublishConsultation(consultationId: string): Promise<{ publicStatus: ConsultationPublicStatus; message: string }> {
+    try {
+      const response = await apiClient.post(`/therapists/consultations/${consultationId}/publish-approve`);
+      return { publicStatus: response.data?.publicStatus, message: response.data?.message };
+    } catch (error: unknown) {
+      console.error('Failed to approve publish:', error);
+      this.throwApiError(error, '同意公開失敗，請稍後再試');
+    }
+  }
+
+  // Pull a pending/published consultation back to private.
+  async withdrawPublishConsultation(consultationId: string): Promise<{ publicStatus: ConsultationPublicStatus; message: string }> {
+    try {
+      const response = await apiClient.post(`/therapists/consultations/${consultationId}/publish-withdraw`);
+      return { publicStatus: response.data?.publicStatus, message: response.data?.message };
+    } catch (error: unknown) {
+      console.error('Failed to withdraw publish:', error);
+      this.throwApiError(error, '取消公開失敗，請稍後再試');
+    }
+  }
+
+  // Public read-only browse of published Q&A threads.
+  async getPublicQa(focus?: TherapistFocusArea, page = 1): Promise<PublicQaListResult> {
+    try {
+      const response = await apiClient.get('/therapists/qa', {
+        params: { ...(focus ? { focus } : {}), page },
+      });
+      const d = response.data || {};
+      return { page: d.page || page, hasMore: Boolean(d.hasMore), threads: (d.threads || []) as PublicQaThreadSummary[] };
+    } catch (error: unknown) {
+      console.error('Failed to fetch public Q&A:', error);
+      this.throwApiError(error, '無法取得公開問答列表');
+    }
+  }
+
+  async getPublicQaThread(id: string): Promise<PublicQaThread> {
+    try {
+      const response = await apiClient.get(`/therapists/qa/${id}`);
+      return response.data?.thread as PublicQaThread;
+    } catch (error: unknown) {
+      console.error('Failed to fetch public Q&A thread:', error);
+      this.throwApiError(error, '無法載入公開問答');
+    }
+  }
+
+  // Toggle a "helpful" vote. Returns the new state + count.
+  async votePublicQa(id: string): Promise<{ voted: boolean; helpfulCount: number }> {
+    try {
+      const response = await apiClient.post(`/therapists/qa/${id}/vote`);
+      return { voted: Boolean(response.data?.voted), helpfulCount: response.data?.helpfulCount ?? 0 };
+    } catch (error: unknown) {
+      console.error('Failed to vote public Q&A:', error);
+      this.throwApiError(error, '操作失敗，請稍後再試');
+    }
+  }
+
+  // --- Therapist reviews (客戶評價) ---
+
+  async getTherapistReviews(therapistId: string): Promise<TherapistReviewsResult> {
+    try {
+      const response = await apiClient.get(`/therapists/${therapistId}/reviews`);
+      const d = response.data || {};
+      return {
+        summary: d.summary || { count: 0, avgRating: null },
+        canReview: Boolean(d.canReview),
+        alreadyReviewed: Boolean(d.alreadyReviewed),
+        reviews: (d.reviews || []) as TherapistReview[],
+      };
+    } catch (error: unknown) {
+      console.error('Failed to fetch therapist reviews:', error);
+      this.throwApiError(error, '無法取得評價');
+    }
+  }
+
+  async submitTherapistReview(
+    therapistId: string,
+    input: { body: string; rating?: number | null; displayName?: string },
+  ): Promise<{ message: string }> {
+    try {
+      const response = await apiClient.post(`/therapists/${therapistId}/reviews`, input);
+      return { message: response.data?.message || '感謝你的評價！' };
+    } catch (error: unknown) {
+      console.error('Failed to submit therapist review:', error);
+      this.throwApiError(error, '送出評價失敗，請稍後再試');
+    }
+  }
+
+  // --- Paid video sessions (視訊諮商) ---
+
+  // Book a paid session (off a free chat), then call paySession to charge it.
+  async bookVideoSession(
+    therapistId: string,
+    input: { message?: string; preferredTime?: string; sourceConsultationId?: string },
+  ): Promise<{ id: string; priceTwd: number }> {
+    try {
+      const response = await apiClient.post(`/therapists/${therapistId}/book-video`, input);
+      const c = response.data?.consultation || {};
+      return { id: c.id, priceTwd: c.priceTwd };
+    } catch (error: unknown) {
+      console.error('Failed to book video session:', error);
+      this.throwApiError(error, '預約失敗，請稍後再試');
+    }
+  }
+
+  // Start ECPay checkout for a booked session; redirects the browser on success.
+  async paySession(consultationId: string): Promise<void> {
+    try {
+      const response = await apiClient.post(`/therapists/consultations/${consultationId}/pay`);
+      const { action_url, params } = response.data || {};
+      if (!action_url || !params) throw new Error('付款資料異常，請稍後再試');
+      submitEcpayForm(action_url, params);
+    } catch (error: unknown) {
+      console.error('Failed to start session payment:', error);
+      this.throwApiError(error, '無法建立付款，請稍後再試');
+    }
+  }
+
+  // Therapist responds to a booking: accept / decline / complete / no_show.
+  async respondConsultation(
+    consultationId: string,
+    action: 'accept' | 'decline' | 'complete' | 'no_show',
+    note?: string,
+  ): Promise<void> {
+    try {
+      await apiClient.post(`/therapists/consultations/${consultationId}/respond`, { action, note });
+    } catch (error: unknown) {
+      console.error('Failed to respond to consultation:', error);
+      this.throwApiError(error, '回覆預約失敗，請稍後再試');
+    }
+  }
+
+  // Therapist sets the third-party meeting link (after accepting).
+  async setMeetingLink(consultationId: string, provider: MeetingProvider, url: string): Promise<void> {
+    try {
+      await apiClient.post(`/therapists/consultations/${consultationId}/meeting-link`, { provider, url });
+    } catch (error: unknown) {
+      console.error('Failed to set meeting link:', error);
+      this.throwApiError(error, '設定會議連結失敗，請稍後再試');
+    }
+  }
+
+  async getMyEarnings(): Promise<TherapistEarnings> {
+    try {
+      const response = await apiClient.get('/therapists/me/earnings');
+      return response.data?.earnings as TherapistEarnings;
+    } catch (error: unknown) {
+      console.error('Failed to fetch earnings:', error);
+      this.throwApiError(error, '無法取得收入資料');
     }
   }
 }

--- a/tests/therapist-flow.spec.ts
+++ b/tests/therapist-flow.spec.ts
@@ -52,6 +52,13 @@ async function openTherapists(page: Page) {
   await expect(page.getByTestId('therapists-view')).toBeVisible({ timeout: 10000 });
 }
 
+// The view opens on the 公開問答 tab; the directory (cards + booking) lives under
+// the 找諮商師 tab, so switch to it before browsing/booking.
+async function openDirectoryTab(page: Page) {
+  await page.getByTestId('therapist-tab-directory').click();
+  await expect(page.getByTestId('therapist-card').first()).toBeVisible({ timeout: 10000 });
+}
+
 test.describe('Therapist counseling', () => {
   test('public sign-up page accepts an application', async ({ page }) => {
     await page.goto(`${BACKEND_BASE}/therapist-signup`);
@@ -74,6 +81,7 @@ test.describe('Therapist counseling', () => {
   test('browse, book, and chat in a consultation room', async ({ page }) => {
     await login(page);
     await openTherapists(page);
+    await openDirectoryTab(page);
 
     // Browse: the seeded therapists should render as cards.
     const firstCard = page.getByTestId('therapist-card').first();
@@ -102,5 +110,26 @@ test.describe('Therapist counseling', () => {
       page.getByTestId('chat-send').click(),
     ]);
     await expect(page.getByTestId('chat-messages')).toContainText(msg, { timeout: 10000 });
+  });
+
+  test('公開問答 tab is the default and the full profile shows reviews', async ({ page }) => {
+    await login(page);
+    await openTherapists(page);
+
+    // The view opens on the 公開問答 (Public Q&A) tab.
+    await expect(page.getByTestId('public-qa-view')).toBeVisible({ timeout: 10000 });
+
+    // Switch to 找諮商師 and open a therapist's full profile.
+    await openDirectoryTab(page);
+    await page.getByTestId('therapist-card').first().getByTestId('therapist-profile-button').click();
+
+    // The enriched profile modal renders with the client-reviews section.
+    await expect(page.getByTestId('therapist-profile-modal')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('reviews-section')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('reviews-section')).toContainText('客戶評價');
+
+    // Booking from the profile leads into the consultation booking modal.
+    await page.getByTestId('profile-book-button').click();
+    await expect(page.getByTestId('consultation-modal')).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary

Builds out therapist monetization in four shippable phases, plus a profile-enrichment request, modeled on the agreed plan. All payouts to therapists are **manual** by design — ECPay AioCheckOut only *collects*; disbursement is recorded via admin "mark-paid".

## What's included

**P1 — Signup profit-sharing** (`public/therapist-signup.html`)
- 分潤與付款 section: free chat, 公開問答 pool, paid video. Live take-home calculator reads the 費率 field (NT$1,600 → intro NT$1,440 / standard NT$1,280).

**P2 — Public Q&A (公開問答)**
- Publish an existing free chat via a **two-party consent handshake** (one side proposes, the other approves; either can withdraw).
- Anonymised, read-only browse (asker → 「匿名個案」, never leaks name/user_id) + helpful-vote toggle.
- New tab split in `TherapistsView`: 公開問答 (default) / 找諮商師.

**P3 — Paid video sessions + ECPay**
- Book off a free chat → ECPay checkout (mirrors `routes/billing.js`) → therapist pastes Zoom/Google Meet link (shown only once paid) → accept/complete/no-show.
- Platform fee **20%**, **10% intro for a therapist's first 10 completed sessions**; fee split computed at pay time and snapshotted per session. Idempotent callback, MAC + amount-tamper guards.
- Therapist earnings view (`/me/earnings` + EarningsModal).

**P4 — Monthly Q&A revenue pool + admin**
- `lib/qaPool.js`: swappable even → volume → engagement split, rounding remainder reconciled so shares sum exactly.
- Admin endpoints: create / compute / finalize / mark-paid. New **分潤** dashboard tab.

**Profile enrichment + reviews** (interjected request, modeled on seeingcounseling.com)
- Rich profile sections: 證照 / 現任 / 專業資格 / 專業訓練 / 著作 / 文章 + welcome / approach / about.
- Moderated client reviews with anonymised names (王小明 → 王O明); new **評價** admin tab.

## Data model
Migrations **045–048** (public-Q&A consent + votes; session bookings + payment orders; revenue pool + shares; rich profile + reviews).

## Verification
- **60 backend integration assertions** pass (P2: 14, profile/reviews: 19, P3 ECPay incl. signed callback simulation: 18, P4 pool: 9).
- `tsc` clean · production build passes · lint adds zero new errors.
- **Playwright** (Mobile Chrome): existing flows updated for the tab split + a new public-Q&A/full-profile/reviews test — **3 passing**.
- Admin dashboard tabs render and are Basic-Auth gated.

## Notes for review
- Payouts (pool + video net) are recorded via admin "mark-paid", not auto-transferred (AioCheckOut limitation).
- ECPay session charge clones the verified billing pattern; tested against stage credentials.
- Two pre-existing `_unused` lint errors in `src/services/api.ts` are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)