### PR TITLE
fix(admin): repair broken dashboard inline script + add Playwright admin tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,10 @@ jobs:
       
       - name: Build frontend
         run: npm run build
-      
+
+      - name: Validate admin dashboard inline script
+        run: npm run check:admin
+
       - name: Set up test database and run tests
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/twogether_test

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e:headed": "npx playwright test --headed",
     "test:e2e:debug": "npx playwright test --debug",
     "lint": "eslint .",
+    "check:admin": "node scripts/check-admin-inline-script.js",
     "migrate": "node scripts/migrate.js migrate",
     "migrate:status": "node scripts/migrate.js status"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -61,6 +61,8 @@ export default defineConfig({
         NODE_ENV: 'test',
         DATABASE_URL: process.env.DATABASE_URL || 'postgresql://twogether:twogether123@localhost:5432/twogether_test',
         JWT_SECRET: process.env.JWT_SECRET || 'dev-secret-do-not-use-in-prod',
+        // Enables the /admin dashboard in tests (adminAuth 503s without it).
+        ADMIN_PASSWORD: process.env.ADMIN_PASSWORD || 'test-admin-pw',
         PORT: '8080'
       }
     },

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1051,7 +1051,7 @@ const ADMIN_HTML = `<!doctype html>
     }
 
     async function deleteTherapist(id, name, btn) {
-      if (!window.confirm('確定要永久刪除諮商師「' + (name || '') + '」嗎？此動作無法復原。\n（若只是想暫時下架，請改用「暫停」。）')) return;
+      if (!window.confirm('確定要永久刪除諮商師「' + (name || '') + '」嗎？此動作無法復原。\\n（若只是想暫時下架，請改用「暫停」。）')) return;
       btn.disabled = true;
       try {
         var res = await fetch('/api/admin/therapists/' + id, { method: 'DELETE' });

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1306,4 +1306,7 @@ if (process.env.NODE_ENV !== 'test') {
   setTimeout(purgeOldLandingVisits, 30_000).unref();
 }
 
-module.exports = { publicRouter, adminApiRouter, htmlHandler, purgeOldLandingVisits };
+// ADMIN_HTML is exported so scripts/check-admin-inline-script.js can validate
+// the embedded <script> (which lives inside a template literal and is therefore
+// invisible to eslint / `node --check` on this module).
+module.exports = { publicRouter, adminApiRouter, htmlHandler, purgeOldLandingVisits, ADMIN_HTML };

--- a/routes/therapists.js
+++ b/routes/therapists.js
@@ -1985,8 +1985,11 @@ adminRouter.post('/qa/shares/:id/mark-paid', express.json(), async (req, res) =>
 // GET /api/admin/therapists/qa/pools — list pools (newest first).
 adminRouter.get('/qa/pools', async (req, res) => {
   try {
+    // period_month via to_char so server-timezone Date serialization (node-pg
+    // parses DATE to a local-midnight Date) can't shift the displayed month.
     const result = await db.query(`
-      SELECT p.*,
+      SELECT p.id, to_char(p.period_month, 'YYYY-MM-DD') AS period_month,
+        p.pool_twd, p.split_strategy, p.status, p.computed_at, p.finalized_at, p.created_at,
         (SELECT COUNT(*) FROM qa_revenue_shares s WHERE s.pool_id = p.id) AS recipient_count,
         (SELECT COALESCE(SUM(share_twd),0) FROM qa_revenue_shares s WHERE s.pool_id = p.id) AS allocated_twd
       FROM qa_revenue_pools p ORDER BY p.period_month DESC
@@ -2001,7 +2004,11 @@ adminRouter.get('/qa/pools', async (req, res) => {
 // GET /api/admin/therapists/qa/pools/:id — pool + per-therapist shares.
 adminRouter.get('/qa/pools/:id', async (req, res) => {
   try {
-    const pool = await db.query(`SELECT * FROM qa_revenue_pools WHERE id = $1`, [req.params.id]);
+    const pool = await db.query(`
+      SELECT id, to_char(period_month, 'YYYY-MM-DD') AS period_month,
+        pool_twd, split_strategy, status, computed_at, finalized_at, created_at
+      FROM qa_revenue_pools WHERE id = $1
+    `, [req.params.id]);
     if (pool.rows.length === 0) return res.status(404).json({ success: false, message: 'Pool not found' });
     const shares = await db.query(`
       SELECT s.*, t.display_name AS therapist_name

--- a/scripts/check-admin-inline-script.js
+++ b/scripts/check-admin-inline-script.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Guards against syntax errors in the /admin dashboard's inline <script>.
+//
+// That script lives inside a JS *template literal* in routes/admin.js, so eslint
+// and `node --check routes/admin.js` see it as a string, not code — a stray
+// escape (e.g. `\n` inside a JS string, which the template literal turns into a
+// real newline) produces a broken SERVED script that only fails in the browser
+// ("Invalid or unexpected token"), killing the whole dashboard.
+//
+// Here we take the rendered HTML, extract each <script>, and PARSE it with
+// vm.Script (compile-only — it never executes, so browser globals like
+// `document`/`window` are irrelevant). Any SyntaxError fails the build. This is
+// the fast, browser-free counterpart to the Playwright admin `pageerror` guard.
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test'; // skip admin.js retention timer
+const vm = require('vm');
+const { ADMIN_HTML } = require('../routes/admin');
+
+const blocks = [...ADMIN_HTML.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+if (blocks.length === 0) {
+  console.error('✗ No inline <script> found in admin HTML');
+  process.exit(1);
+}
+
+let failed = false;
+blocks.forEach((code, i) => {
+  try {
+    // Parse only — does not run the script.
+    new vm.Script(code, { filename: `admin-inline-script-${i}.js` });
+  } catch (e) {
+    failed = true;
+    console.error(`✗ admin inline <script> #${i} has a syntax error: ${e.message}`);
+  }
+});
+
+if (failed) process.exit(1);
+console.log(`✓ admin inline script OK (${blocks.length} block(s) parsed)`);
+process.exit(0);

--- a/tests/admin-dashboard.spec.ts
+++ b/tests/admin-dashboard.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// E2E for the /admin dashboard (Basic-Auth gated, served by the Express backend
+// on :8080). The dashboard's interactivity lives in one inline <script>, so a
+// single syntax error there silently kills ALL of it (tabs stop switching, data
+// never loads) — which is exactly the "Invalid or unexpected token" regression
+// this suite guards against. We assert: (1) no uncaught page errors, (2) every
+// tab switches, (3) the Q&A pool + reviews tabs actually function.
+
+const BACKEND_BASE = process.env.PLAYWRIGHT_BACKEND_BASE || 'http://localhost:8080';
+const ADMIN_PW = process.env.ADMIN_PASSWORD || 'test-admin-pw';
+
+// Basic-Auth for every request in this file.
+test.use({ httpCredentials: { username: 'admin', password: ADMIN_PW } });
+
+// Collect uncaught errors from the page. A broken inline <script> (e.g. an
+// unescaped newline inside a JS string) surfaces here as a 'pageerror'.
+function trackPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  return errors;
+}
+
+test.describe('Admin dashboard', () => {
+  test('loads with no script errors and every tab switches', async ({ page }) => {
+    const errors = trackPageErrors(page);
+    await page.goto(`${BACKEND_BASE}/admin`);
+    await page.waitForLoadState('domcontentloaded');
+
+    // Default panel is the funnel.
+    await expect(page.locator('#panel-funnel')).toHaveClass(/active/);
+
+    // Each tab activates its panel — proves the inline script parsed and the
+    // delegated click handler is live.
+    for (const panel of ['pages', 'retention', 'therapists', 'reviews', 'pool']) {
+      await page.locator(`.tab[data-panel="${panel}"]`).click();
+      await expect(page.locator(`#panel-${panel}`)).toHaveClass(/active/);
+    }
+
+    expect(errors, `uncaught page errors: ${errors.join(' | ')}`).toEqual([]);
+  });
+
+  test('Q&A revenue pool: create then compute shows shares', async ({ page }) => {
+    const errors = trackPageErrors(page);
+    await page.goto(`${BACKEND_BASE}/admin`);
+    await page.locator('.tab[data-panel="pool"]').click();
+    await expect(page.locator('#panel-pool')).toHaveClass(/active/);
+
+    const month = new Date().toISOString().slice(0, 7); // YYYY-MM (month input format)
+    await page.fill('#poolMonth', month);
+    await page.fill('#poolAmount', '1000');
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/qa/pools') && r.request().method() === 'POST', { timeout: 15000 }),
+      page.click('#poolCreate'),
+    ]);
+
+    // The new pool appears in the table (idempotent: re-runs update the row).
+    await expect(page.locator('#poolsTable')).toContainText(month, { timeout: 10000 });
+
+    // Compute the split → the per-therapist shares detail becomes visible.
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/compute') && r.request().method() === 'POST', { timeout: 15000 }),
+      page.locator('#poolsTable button[data-pool="compute"]').first().click(),
+    ]);
+    await expect(page.locator('#poolDetail')).toBeVisible({ timeout: 10000 });
+
+    expect(errors, `uncaught page errors: ${errors.join(' | ')}`).toEqual([]);
+  });
+
+  test('reviews moderation tab loads its table', async ({ page }) => {
+    const errors = trackPageErrors(page);
+    await page.goto(`${BACKEND_BASE}/admin`);
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/therapists/reviews'), { timeout: 15000 }),
+      page.locator('.tab[data-panel="reviews"]').click(),
+    ]);
+    await expect(page.locator('#reviewsTable')).toBeVisible();
+    expect(errors, `uncaught page errors: ${errors.join(' | ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What was broken

The production `/admin` dashboard threw **`Uncaught SyntaxError: Invalid or unexpected token (at admin:575:58)`**, which killed the entire inline `<script>` — so tabs stopped switching and no data loaded.

**Root cause (pre-existing, predates the monetization PR):** the dashboard's JS lives inside a JS *template literal* in `routes/admin.js`. A `\n` in the `deleteTherapist` confirm string is interpreted by the template literal as a real newline, so the *served* page had a single-quoted string broken across two lines. `node --check routes/admin.js` never caught it because there the script is a string, not code.

## Fixes
- **Escape the newline** (`\n` → `\\n`) so the served JS is valid. Verified by extracting the served `<script>` and running `node --check` on it → clean.
- **Timezone bug** in the Q&A pool admin endpoints: `period_month` (a `DATE`) was serialized through a local-midnight `Date` and showed a month early in UTC+8. Now returned via `to_char(..., 'YYYY-MM-DD')` so the displayed month is stable regardless of server TZ.

## Prevention (the ask: "how do we prevent this in future" + admin Playwright test)
- **`tests/admin-dashboard.spec.ts`** (Basic-Auth via `httpCredentials`):
  - **`pageerror` guard** — any uncaught error in the inline script fails the test. This is the direct regression guard for this exact bug (broken script ⇒ no JS ⇒ assertions fail).
  - Asserts **every tab switches** (funnel/pages/retention/therapists/reviews/pool).
  - Exercises the **Q&A pool create → compute** flow and the **reviews** tab end-to-end.
- `playwright.config.ts` sets `ADMIN_PASSWORD` for the test backend so `/admin` is reachable in CI.

### Longer-term note
The structural root cause is that the admin script is embedded in a template literal, so escapes/`${}` get reinterpreted and normal lint/`node --check` can't see it. A future cleanup could extract it to a real static `.js` file (linted/type-checked normally). The Playwright `pageerror` guard covers it in CI in the meantime.

## Verification
- Served admin `<script>` passes `node --check`.
- **Playwright: 3 admin tests pass** (Mobile Chrome); the broader suite stays green (one unrelated pre-existing flaky script-thumbnail test passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)