### PR TITLE
fix(roleplay): fit lightbox image within viewport on mobile

### DIFF
--- a/src/components/RoleplayView.tsx
+++ b/src/components/RoleplayView.tsx
@@ -1334,7 +1334,7 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
         {lightboxOpen && lightboxPhotos.length > 0 && (
           <div
             data-testid="roleplay-modal-lightbox"
-            className="fixed inset-0 z-[60] bg-black/85 flex items-center justify-center overflow-auto overscroll-contain p-4 sm:p-8"
+            className="fixed inset-0 z-[60] bg-black/85 flex items-center justify-center overflow-hidden overscroll-contain p-3 sm:p-8"
             onClick={() => setLightboxOpen(false)}
             role="dialog"
             aria-modal="true"
@@ -1383,7 +1383,9 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
               src={lightboxPhotos[lightboxIndex]}
               alt={`${selectedScript.title} ${lightboxIndex + 1}`}
               onClick={(e) => e.stopPropagation()}
-              className="block max-w-none cursor-default"
+              // Fit the whole image within the viewport on any screen — never
+              // crop or overflow. max-h/max-w + object-contain letterboxes it.
+              className="block max-h-full max-w-full w-auto h-auto object-contain cursor-default"
               data-testid="roleplay-modal-lightbox-image"
             />
           </div>

--- a/tests/roleplay-photos.spec.ts
+++ b/tests/roleplay-photos.spec.ts
@@ -103,6 +103,28 @@ test.describe('Roleplay custom script — multi-photo upload + lightbox nav', ()
     await page.getByTestId('roleplay-modal-lightbox-prev').click();
     await expect(page.getByTestId('roleplay-modal-lightbox-counter')).toHaveText('1 / 2');
 
+    // A large, off-aspect image must fit entirely within the (mobile) viewport —
+    // never overflow it. Swap in a 2400x1600 image and measure the rendered box.
+    const fit = await page.evaluate(async () => {
+      const img = document.querySelector(
+        '[data-testid="roleplay-modal-lightbox-image"]',
+      ) as HTMLImageElement | null;
+      if (!img) return null;
+      const c = document.createElement('canvas');
+      c.width = 2400;
+      c.height = 1600;
+      const ctx = c.getContext('2d')!;
+      ctx.fillStyle = '#c33';
+      ctx.fillRect(0, 0, c.width, c.height);
+      img.src = c.toDataURL('image/png');
+      await img.decode();
+      const r = img.getBoundingClientRect();
+      return { w: r.width, h: r.height, vw: window.innerWidth, vh: window.innerHeight };
+    });
+    expect(fit, 'lightbox image present').not.toBeNull();
+    expect(fit!.w).toBeLessThanOrEqual(fit!.vw + 1);
+    expect(fit!.h).toBeLessThanOrEqual(fit!.vh + 1);
+
     await page.getByTestId('roleplay-modal-lightbox-close').click();
     await expect(page.getByTestId('roleplay-modal-lightbox')).toBeHidden({ timeout: 5000 });
   });


### PR DESCRIPTION
## Problem
On mobile, the script photo lightbox image overflowed the screen — you couldn't see the whole picture. The image used `max-w-none` (no width cap), so it rendered at its natural pixel size.

## Fix
Constrain the lightbox image with `max-h-full max-w-full object-contain` so it's letterboxed to fit within the viewport on any screen size/orientation (never cropped, never overflowing), and switch the container from `overflow-auto` to `overflow-hidden` since it no longer needs to scroll. Trimmed mobile padding slightly (`p-3`) for a touch more image area.

## Verification
`tests/roleplay-photos.spec.ts` now injects a 2400×1600 image into the open lightbox and asserts its rendered bounding box stays within the Mobile Chrome viewport (`w ≤ vw`, `h ≤ vh`) — this fails under the old `max-w-none` and passes with the fix. Full suite green (30/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)