### PR TITLE
feat(intimacy): gender-aware AI roleplay invitations

### DIFF
--- a/routes/intimacy-requests.js
+++ b/routes/intimacy-requests.js
@@ -161,11 +161,22 @@ async function ensureRoleplaySuggestionTables() {
 
 // Stable fingerprint of a script's content so an edited script regenerates while
 // identical content is reused (and shared across couples).
-function roleplayContentHash({ title, scenario, scriptBody, category }) {
+function roleplayContentHash({ title, scenario, scriptBody, category, senderGender }) {
   return crypto
     .createHash('sha256')
-    .update([title || '', scenario || '', scriptBody || '', category || ''].join(''))
+    .update([title || '', scenario || '', scriptBody || '', category || '', senderGender || ''].join(''))
     .digest('hex');
+}
+
+// The sender's gender drives which role in the script the invitation speaks from.
+async function getUserGender(userId) {
+  try {
+    const r = await db.query('SELECT gender FROM users WHERE id = $1', [userId]);
+    return r.rows[0]?.gender || null;
+  } catch (err) {
+    logWarn('getUserGender failed', { err: err.message });
+    return null;
+  }
 }
 
 const normalizeCount = (value) => {
@@ -400,10 +411,14 @@ router.post('/script-messages', [
 
   const userId = req.user.id;
   const { scriptId, scriptTitle, scriptScenario, scriptBody, category, regenerate } = req.body;
-  const contentHash = roleplayContentHash({ title: scriptTitle, scenario: scriptScenario, scriptBody, category });
 
   try {
     await ensureRoleplaySuggestionTables();
+
+    // The sender's gender selects which role in the script the messages speak
+    // from; it's part of the cache key so different-gender senders don't share.
+    const senderGender = await getUserGender(userId);
+    const contentHash = roleplayContentHash({ title: scriptTitle, scenario: scriptScenario, scriptBody, category, senderGender });
 
     // Cache hit (only when we have a scriptId and aren't forcing a regenerate).
     if (scriptId && !regenerate) {
@@ -433,13 +448,14 @@ router.post('/script-messages', [
       return res.status(limitCheck.status).json(limitCheck.body);
     }
 
-    logInfo('intimacy.script_messages.input', { userId, scriptId, scriptTitle, category, regenerate: !!regenerate, hasBody: !!scriptBody });
+    logInfo('intimacy.script_messages.input', { userId, scriptId, scriptTitle, category, senderGender, regenerate: !!regenerate, hasBody: !!scriptBody });
 
     const result = await llmService.generateRoleplayMessages({
       title: scriptTitle,
       scenario: scriptScenario,
       scriptBody,
       category,
+      senderGender,
     });
     const meta = result._meta;
     delete result._meta;

--- a/services/llm/claudeProvider.js
+++ b/services/llm/claudeProvider.js
@@ -232,10 +232,18 @@ const ROLEPLAY_SYSTEM_PROMPT = `你是一個專為「成熟情侶」設計的角
 守則：
 - 所有訊息都是傳給「同意的伴侶」、用來開啟雙方都期待的角色扮演，語氣是邀請與渴望，而不是命令或施壓。
 - 緊扣使用者提供的劇本情境與角色身分，不要編造與劇本無關的全新設定。
+- 性別與視角（重要）：訊息是由「傳送者」發出的。請依「傳送者性別」判斷傳送者在劇本中對應的角色，並以該角色的視角撰寫。例如劇本女主角是小香，但傳送者是男性，就要以劇本中的男性角色視角發出邀請（把女主角當成被邀請的對象），絕不能用女主角的視角自稱。若性別為「未指定」，則用中性、不限定自身性別的傳送者視角撰寫。
 - 即使某一級你判斷不適合產生，也務必回傳其餘等級，並為該級填入較收斂的替代文字 — 不可整批拒答或回傳少於 5 則。
 - 使用繁體中文，自然口語，像真的在傳訊息。
 
 回應請只呼叫 emit_roleplay_messages tool，不要輸出其他文字。`;
+
+// Maps the stored gender enum to a Chinese label used in the prompt.
+function genderLabel(g) {
+  if (g === 'male') return '男性';
+  if (g === 'female') return '女性';
+  return '未指定';
+}
 
 const ROLEPLAY_TOOL_SCHEMA = {
   name: 'emit_roleplay_messages',
@@ -262,12 +270,13 @@ const ROLEPLAY_TOOL_SCHEMA = {
   },
 };
 
-async function generateRoleplayMessages({ title, scenario, scriptBody, category }) {
+async function generateRoleplayMessages({ title, scenario, scriptBody, category, senderGender }) {
   if (typeof title !== 'string' || title.trim().length === 0) {
     throw new Error('title is required');
   }
 
   const userContent = [
+    `傳送者性別：${genderLabel(senderGender)}`,
     `劇本標題：${title.trim()}`,
     category ? `分類：${String(category).trim()}` : null,
     scenario ? `情境：${String(scenario).trim()}` : null,

--- a/services/llm/mockProvider.js
+++ b/services/llm/mockProvider.js
@@ -162,13 +162,14 @@ const ROLEPLAY_LEVELS = [
   { key: 'intense', label: '最強烈' },
 ];
 
-async function generateRoleplayMessages({ title, scenario /* , scriptBody, category */ }) {
+async function generateRoleplayMessages({ title, scenario, senderGender /* , scriptBody, category */ }) {
   if (typeof title !== 'string' || title.trim().length === 0) {
     throw new Error('title is required');
   }
   const startedAt = Date.now();
   const t = title.trim();
-  const summary = `${t}：${(scenario || '一段專屬你們的角色扮演').toString().trim()}。一起入戲，今晚就從這裡開始。`;
+  const genderTag = senderGender === 'male' ? '（男性視角）' : senderGender === 'female' ? '（女性視角）' : '';
+  const summary = `${t}${genderTag}：${(scenario || '一段專屬你們的角色扮演').toString().trim()}。一起入戲，今晚就從這裡開始。`;
   const lines = [
     `今晚想和你玩《${t}》，先當作我們剛在場景裡相遇，好嗎？`,
     `想到等下要和你演《${t}》，我心跳有點快…你準備好入戲了嗎？`,

--- a/tests/roleplay-invitation.spec.ts
+++ b/tests/roleplay-invitation.spec.ts
@@ -39,6 +39,9 @@ async function ensurePaired() {
   const ctxA = await request.newContext({ extraHTTPHeaders: { Authorization: `Bearer ${tokenA}` } });
   const ctxB = await request.newContext({ extraHTTPHeaders: { Authorization: `Bearer ${tokenB}` } });
   try {
+    // Sender is male — the AI invitation should speak from the male role.
+    await ctxA.put(`${API}/auth/user/gender`, { data: { gender: 'male' } });
+
     if (await isComplete(ctxA)) return;
 
     const codeRes = await ctxA.post(`${API}/couples/pairing-code`, { data: {} });
@@ -117,7 +120,10 @@ test.describe('Roleplay AI invitation flow', () => {
     await firstScript.click();
     await genResp;
 
-    // Step 3: exactly the 5 escalating levels, low → high.
+    // Step 3: exactly the 5 escalating levels, low → high. The sender's gender
+    // (set to male in beforeAll) flows into generation server-side; we don't
+    // assert on the model's natural-language output here since the test server
+    // uses the real LLM (non-deterministic).
     for (const lvl of LEVELS) {
       await expect(page.getByTestId(`roleplay-msg-${lvl}`)).toBeVisible({ timeout: 15000 });
     }


### PR DESCRIPTION
## Problem
The AI-generated roleplay invitation messages didn't account for the sender's gender. A male user sending an invitation got text written from the female lead's perspective (e.g. speaking as 小香) — wrong role.

## Fix
The sender's gender (already in their profile, `users.gender`) now drives which role in the script the invitation speaks from.

- **`routes/intimacy-requests.js`** — fetches the sender's gender and passes it into generation. It's also folded into the cache `content_hash`, so a male and a female sender don't share cached output for the same script.
- **`claudeProvider`** — the prompt now receives `傳送者性別` and is instructed to write from the sender-gender's role: e.g. *female lead 小香 + male sender → speak as the male character inviting her*, never self-identify as the female lead. Neutral fallback when gender is unspecified. (mockProvider tags the summary by gender for deterministic local checks.)

## Verification
- Manual real-API run (Claude Haiku 4.5) on a script with a female lead:
  - **male sender** → speaks as the photographer/male role inviting "妳"
  - **female sender** → speaks from her own role
- `roleplay-invitation` e2e sets the sender to male so the gender code path runs end-to-end. It doesn't assert on the model's natural-language output because the test server uses the real (non-deterministic) LLM. Full suite green (30/30).

No frontend change — gender is read server-side from the user record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)