### PR TITLE
feat(roleplay): script created date, NEW tag, and share-to-partner

### DIFF
--- a/routes/custom-scripts.js
+++ b/routes/custom-scripts.js
@@ -8,7 +8,8 @@ const { authenticateToken } = require('../middleware/auth');
 const { uploadToSupabase } = require('../lib/supabase-storage');
 const { getCoupleTier, getLimit, checkLimit } = require('../lib/entitlements');
 const { logDbError, errorResponseBody } = require('../lib/db-errors');
-const { logError, logInfo } = require('../lib/logger');
+const { logError, logInfo, logWarn } = require('../lib/logger');
+const emailService = require('../services/emailService');
 
 const router = express.Router();
 
@@ -559,6 +560,65 @@ router.delete('/:id', async (req, res) => {
       success: false,
       message: '刪除劇本失敗'
     });
+  }
+});
+
+// POST /:id/share — email the requester's partner about this script to spark
+// interest ("come log in and take a look"). Deliberate user action, so it
+// reports clear feedback (unpaired / no email / opted out) rather than failing
+// silently. Honors the partner's "Email 通知" switch.
+router.post('/:id/share', async (req, res) => {
+  try {
+    const scriptId = req.params.id;
+    const userId = req.user.id;
+
+    // The script must exist and belong to the user (or their couple).
+    const scriptResult = await db.query(`
+      SELECT cs.id, cs.title, cs.scenario
+      FROM custom_scripts cs
+      LEFT JOIN couples c ON cs.couple_id = c.id
+      WHERE cs.id = $1 AND (cs.created_by = $2 OR c.user1_id = $2 OR c.user2_id = $2)
+    `, [scriptId, userId]);
+
+    if (scriptResult.rows.length === 0) {
+      return res.status(404).json({ success: false, message: '找不到劇本或無權限分享' });
+    }
+    const script = scriptResult.rows[0];
+
+    // Resolve the partner with clear, distinct feedback per failure mode.
+    const partnerResult = await db.query(`
+      SELECT u.email, u.nickname, u.email_notifications_enabled
+        FROM couples c
+        JOIN users u ON u.id = CASE WHEN c.user1_id = $1 THEN c.user2_id ELSE c.user1_id END
+       WHERE (c.user1_id = $1 OR c.user2_id = $1) AND c.user2_id IS NOT NULL
+    `, [userId]);
+    const partner = partnerResult.rows[0];
+
+    if (!partner) {
+      return res.json({ success: false, message: '你還沒有配對伴侶，無法分享。' });
+    }
+    if (!partner.email) {
+      return res.json({ success: false, message: '找不到伴侶的電子郵件地址，請請伴侶更新資訊。' });
+    }
+    if (partner.email_notifications_enabled === false) {
+      return res.json({ success: false, message: '你的伴侶已關閉 Email 通知，目前無法分享。' });
+    }
+    if (!emailService.isConfigured()) {
+      return res.json({ success: false, message: '信件服務尚未設定，因此暫時無法分享。' });
+    }
+
+    await emailService.sendScriptShareEmail({
+      recipientEmail: partner.email,
+      sharerName: req.user.nickname || '你的伴侶',
+      scriptTitle: script.title,
+      scenario: script.scenario,
+    });
+    logInfo('Custom script shared with partner', { scriptId });
+
+    res.json({ success: true, message: `已將「${script.title}」分享到伴侶的信箱。` });
+  } catch (error) {
+    logWarn('Share custom script failed', { id: req.params.id, err: error.message });
+    res.status(500).json({ success: false, message: '分享失敗，請稍後再試。' });
   }
 });
 

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -1058,6 +1058,54 @@ ${acceptUrl}
       logError('Failed to send consultation confirmation email', { kind: 'consultation_confirm', ...smtpErrorFields(error) });
     }
   }
+
+  // A user shares one of their custom role scripts with their partner to spark
+  // interest. Deliberately light on detail — the point is to nudge the partner
+  // to log in and take a look, not to reproduce the script in the email.
+  async sendScriptShareEmail({ recipientEmail, sharerName, scriptTitle, scenario }) {
+    if (!this.isConfigured() || !recipientEmail) return;
+
+    const safeSharer = this._escape(sharerName || '你的伴侶');
+    const safeTitle = this._escape(scriptTitle || '一個劇本');
+    const safeScenario = this._escape(scenario || '').slice(0, 300);
+
+    const bodyHtml = `
+      <p><strong>${safeSharer}</strong> 想和你一起試試這個角色扮演劇本 💕</p>
+      <div class="quote">
+        <div style="font-weight:600;font-size:16px;">${safeTitle}</div>
+        ${safeScenario ? `<div style="color:#636e72;margin-top:6px;">${safeScenario}</div>` : ''}
+      </div>
+      <p style="color:#636e72;font-size:14px;">登入 Twogether 看看完整劇本，準備好給對方一個驚喜。</p>
+    `;
+    const html = this._activityEmailHtml({
+      headerEmoji: '💌',
+      headerTitle: `${safeSharer} 想和你試試一個劇本`,
+      headerSubtitle: safeTitle,
+      bodyHtml,
+      ctaLabel: '💕 登入查看劇本',
+    });
+
+    const text = [
+      `${sharerName || '你的伴侶'} 想和你一起試試這個角色扮演劇本：`,
+      `「${scriptTitle || '一個劇本'}」`,
+      scenario ? `\n${scenario}` : '',
+      '',
+      '登入 Twogether 看看完整劇本。',
+    ].join('\n');
+
+    try {
+      await this.transporter.sendMail({
+        from: `"Twogether 愛情助手" <${process.env.SMTP_USER}>`,
+        to: recipientEmail,
+        subject: `💌 ${sharerName || '你的伴侶'} 想和你試試「${scriptTitle || '一個劇本'}」`,
+        text,
+        html,
+      });
+      logInfo('Script share email sent', { kind: 'script_share' });
+    } catch (error) {
+      logError('Failed to send script share email', { kind: 'script_share', ...smtpErrorFields(error) });
+    }
+  }
 }
 
 module.exports = new EmailService();

--- a/src/components/RoleplayView.tsx
+++ b/src/components/RoleplayView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Heart, Sparkles, FileText, Plus, Filter, Play, Eye, Pencil, X, Store, ArrowDownWideNarrow, LayoutGrid, List, Gamepad2, ChevronDown, ArrowUp, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Heart, Sparkles, FileText, Plus, Filter, Play, Eye, Pencil, X, Store, ArrowDownWideNarrow, LayoutGrid, List, Gamepad2, ChevronDown, ArrowUp, ChevronLeft, ChevronRight, Share2 } from 'lucide-react';
 import type { Notification } from './ErrorNotification';
 import { useScrollLock } from '../hooks/useScrollLock';
 import { apiService } from '../services/api';
@@ -8,7 +8,7 @@ import StarRating from './StarRating';
 import MarketplaceScriptDetail from './MarketplaceScriptDetail';
 import PetalSelect from './PetalSelect';
 import { useTimezone } from '../contexts/TimezoneContext';
-import { formatYmdInTz } from '../utils/datetime';
+import { formatYmdInTz, formatDate } from '../utils/datetime';
 
 interface RoleplayScript {
   id: string;
@@ -172,6 +172,9 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
   const tz = useTimezone();
   const [selectedScript, setSelectedScript] = useState<RoleplayScript | null>(null);
   const [showScriptModal, setShowScriptModal] = useState(false);
+  // Id of the script currently being shared to the partner's email (disables
+  // that card's share button while the request is in flight).
+  const [sharingId, setSharingId] = useState<string | null>(null);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
   // Tracks whether the current modal viewing has been "begun" — i.e. user
@@ -360,6 +363,41 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
     setHasBegun(false);
     setLightboxOpen(false);
   }, []);
+
+  // Email the script to the partner to spark their interest. The backend
+  // returns a clear message for every outcome (shared / unpaired / opted out),
+  // so we surface it directly and pick the toast tone from `success`.
+  const handleShareScript = useCallback(async (script: RoleplayScript) => {
+    if (sharingId) return;
+    setSharingId(script.id);
+    try {
+      const result = await apiService.shareCustomScript(script.id);
+      showNotification({
+        type: result?.success ? 'success' : 'info',
+        title: result?.success ? '已分享給伴侶' : '尚未分享',
+        message: result?.message || '已將劇本分享到伴侶的信箱。',
+        duration: 5000,
+      });
+    } catch (error) {
+      showNotification({
+        type: 'error',
+        title: '分享失敗',
+        message: (error as Error)?.message || '無法分享劇本，請稍後再試。',
+        duration: 5000,
+      });
+    } finally {
+      setSharingId(null);
+    }
+  }, [sharingId, showNotification]);
+
+  // A custom script counts as "new" for 7 days after creation, so the couple
+  // notices freshly added scripts at a glance.
+  const isRecentlyCreated = (createdAt?: string) => {
+    if (!createdAt) return false;
+    const t = new Date(createdAt).getTime();
+    if (Number.isNaN(t)) return false;
+    return Date.now() - t < 7 * 24 * 60 * 60 * 1000;
+  };
 
   const allScripts = [...defaultRoleplayScripts, ...customScripts];
   const filteredScripts = roleplayFilter === 'all'
@@ -706,7 +744,14 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-start justify-between gap-2">
-                          <h4 className="font-display text-base font-medium tracking-tight text-petal-ink truncate">{script.title}</h4>
+                          <div className="flex items-center gap-1.5 min-w-0">
+                            <h4 className="font-display text-base font-medium tracking-tight text-petal-ink truncate">{script.title}</h4>
+                            {isRecentlyCreated(script.createdAt) && (
+                              <span data-testid={`script-new-badge-${script.id}`} className="flex-shrink-0 px-1.5 py-0.5 font-body text-[10px] font-medium uppercase tracking-[0.1em] rounded-full bg-petal-rose-deep text-petal-cream">
+                                New
+                              </span>
+                            )}
+                          </div>
                           <div className="flex items-center gap-1.5 flex-shrink-0">
                             <span data-testid="script-card-custom-badge" className="px-2 py-0.5 font-body text-[10px] uppercase tracking-[0.1em] rounded-full border border-petal-rule text-petal-muted">
                               自訂
@@ -715,6 +760,11 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
                           </div>
                         </div>
                         <p className="font-body text-sm text-petal-ink-soft mt-1 leading-relaxed">{script.scenario}</p>
+                        {script.createdAt && (
+                          <p data-testid={`script-created-date-${script.id}`} className="font-body text-[11px] text-petal-muted mt-1">
+                            建立於 {formatDate(script.createdAt, tz, { year: 'numeric', month: 'numeric', day: 'numeric', withWeekday: false })}
+                          </p>
+                        )}
                       </div>
                     </div>
                     <div className="flex items-center justify-between mt-3">
@@ -737,6 +787,16 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
                             編輯
                           </button>
                         )}
+                        <button
+                          onClick={() => handleShareScript(script)}
+                          disabled={sharingId === script.id}
+                          data-testid={`script-card-custom-share-button-${script.id}`}
+                          className="border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink px-3 py-1 rounded-full font-body text-xs transition-colors disabled:opacity-50"
+                          aria-label={`分享 ${script.title} 給伴侶`}
+                        >
+                          <Share2 className="w-3 h-3 inline mr-1" strokeWidth={1.5} />
+                          {sharingId === script.id ? '分享中' : '分享'}
+                        </button>
                         <button
                           onClick={() => handleViewScript(script)}
                           data-testid={`script-card-custom-view-button-${script.id}`}
@@ -766,10 +826,22 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
                     testId: `script-card-custom-${script.id}`,
                     script,
                     badge: (
-                      <span data-testid="script-card-custom-badge" className="px-2 py-0.5 font-body text-[10px] uppercase tracking-[0.1em] rounded-full border border-petal-rule text-petal-muted flex-shrink-0">
-                        自訂
-                      </span>
+                      <>
+                        {isRecentlyCreated(script.createdAt) && (
+                          <span data-testid={`script-new-badge-${script.id}`} className="px-1.5 py-0.5 font-body text-[10px] font-medium uppercase tracking-[0.1em] rounded-full bg-petal-rose-deep text-petal-cream flex-shrink-0">
+                            New
+                          </span>
+                        )}
+                        <span data-testid="script-card-custom-badge" className="px-2 py-0.5 font-body text-[10px] uppercase tracking-[0.1em] rounded-full border border-petal-rule text-petal-muted flex-shrink-0">
+                          自訂
+                        </span>
+                      </>
                     ),
+                    metaLine: script.createdAt ? (
+                      <p data-testid={`script-created-date-${script.id}`} className="font-body text-[11px] text-petal-muted mt-0.5">
+                        建立於 {formatDate(script.createdAt, tz, { year: 'numeric', month: 'numeric', day: 'numeric', withWeekday: false })}
+                      </p>
+                    ) : undefined,
                     actions: (
                       <>
                         <span className="hidden sm:inline-flex">
@@ -786,6 +858,16 @@ const RoleplayView: React.FC<RoleplayViewProps> = ({
                             編輯
                           </button>
                         )}
+                        <button
+                          onClick={() => handleShareScript(script)}
+                          disabled={sharingId === script.id}
+                          data-testid={`script-card-custom-share-button-${script.id}`}
+                          className="hidden sm:inline-flex border border-petal-rule text-petal-ink-soft hover:border-petal-ink hover:text-petal-ink px-3 py-1 rounded-full font-body text-xs transition-colors disabled:opacity-50"
+                          aria-label={`分享 ${script.title} 給伴侶`}
+                        >
+                          <Share2 className="w-3 h-3 inline mr-1" strokeWidth={1.5} />
+                          {sharingId === script.id ? '分享中' : '分享'}
+                        </button>
                         <button
                           onClick={() => handleViewScript(script)}
                           data-testid={`script-card-custom-view-button-${script.id}`}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2026,6 +2026,14 @@ class ApiService {
     }
   }
 
+  // Email a custom script to the paired partner to spark their interest. The
+  // backend resolves the partner and returns a clear message for each outcome
+  // (shared / unpaired / opted out), so surface response.message either way.
+  async shareCustomScript(id: string): Promise<{ success: boolean; message: string }> {
+    const response = await apiClient.post(`/custom-scripts/${id}/share`, {});
+    return response.data;
+  }
+
   // Script Favorites API — couple-scoped list of favorited script ids
   // (both built-in default ids and custom UUIDs).
   async getScriptFavorites(): Promise<string[]> {

--- a/tests/custom-script.spec.ts
+++ b/tests/custom-script.spec.ts
@@ -323,4 +323,49 @@ test.describe('Custom Script Upload and Persistence', () => {
       }, { timeout: 5000 })
       .toBe(initialCoins + 200);
   });
+
+  test('a freshly created script shows created date, NEW tag, and a working share button', async ({ page }) => {
+    const roleplayTab = page.getByTestId('nav-tab-roleplay');
+    await expect(roleplayTab).toBeVisible({ timeout: 5000 });
+    await roleplayTab.click();
+    await page.waitForTimeout(1500);
+
+    // Upload a fresh script (created_at = now → should be tagged NEW).
+    await page.getByTestId('script-upload-button').click();
+    await expect(page.locator('h3:has-text("上傳自訂劇本")')).toBeVisible({ timeout: 5000 });
+    const title = `Share Script ${Date.now()}`;
+    await page.locator('input#script-title').fill(title);
+    await page.locator('select#script-category').selectOption('romantic');
+    await page.locator('input#script-scenario').fill('Sharing test scenario');
+    await page.locator('textarea#script-content').fill('[男]: 哈囉\n[女]: 嗨');
+    const submitButton = page.getByTestId('script-upload-submit-button');
+    await submitButton.scrollIntoViewIfNeeded();
+    await submitButton.click();
+
+    await expect(page.locator('text=劇本上傳成功').or(page.locator('text=已加入你的劇本庫')).first())
+      .toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(1500);
+
+    // Created date + NEW tag render on the new card (newest sorts first).
+    await expect(page.locator('[data-testid^="script-created-date-"]').first())
+      .toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid^="script-new-badge-"]').first())
+      .toBeVisible({ timeout: 5000 });
+
+    // Share button is present; clicking it surfaces a toast. The E2E user is
+    // unpaired, so the backend replies with the "no partner" message — either
+    // way a toast appears, proving the round-trip works.
+    const shareButton = page.locator('[data-testid^="script-card-custom-share-button-"]').first();
+    await expect(shareButton).toBeVisible({ timeout: 5000 });
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/share') && r.request().method() === 'POST', { timeout: 15000 }),
+      shareButton.click(),
+    ]);
+    await expect(
+      page.locator('text=已分享給伴侶')
+        .or(page.locator('text=尚未分享'))
+        .or(page.locator('text=還沒有配對伴侶'))
+        .first()
+    ).toBeVisible({ timeout: 10000 });
+  });
 });


### PR DESCRIPTION
Three related additions to custom role-script cards.

## 1. Created date
Every custom script card (grid + list) now shows **建立於 {date}** from `createdAt` (already returned by the API — no schema change).

## 2. NEW tag
A rose **New** badge appears on scripts created within the last **7 days**, so freshly added scripts stand out. Shows immediately after creation (the create response includes `createdAt`).

## 3. Share to partner's email
A **分享** button on each card emails the script to the paired partner to spark interest ("come log in and take a look").
- `POST /api/custom-scripts/:id/share` verifies ownership, resolves the partner, and returns a **clear message per outcome**: shared / unpaired / no email / **opted out** (honors the partner's `email_notifications_enabled` switch).
- `emailService.sendScriptShareEmail` reuses the shared activity template (light on detail by design — title + scenario + a login CTA, not the full script).
- The toast reflects the backend message and picks tone from `success`.

## Verification
- `tsc` clean, `vite build` passes, lint clean on changed files.
- E2E: custom-script + roleplay-favorites + role-script-edit suites green; added a test that uploads a script and asserts the **created date**, **NEW badge**, and a **working share button** (round-trips `POST /share`).

## Note
Sharing is a deliberate user action but still respects the partner's email opt-out (consistent with the intimacy-message / nudge behavior). If you'd rather sharing always send regardless of the switch, that's a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)